### PR TITLE
Rwahs 35/acquisition import

### DIFF
--- a/rwahs.xml
+++ b/rwahs.xml
@@ -1484,6 +1484,27 @@
               <settings>
                 <setting name="label" locale="en_AU">Source / Donor</setting>
                 <setting name="restrictToRelationshipTypes">donor</setting>
+                <setting name="display_template"><![CDATA[
+                <table class="table-bordered">
+                  <tr><th>Donor Name<l></th><td><l>^preferred_labels</l>(^type_id)</td></tr>
+                  <tr><th>Address</th>
+                  <td><pre>^ca_entities.AddressContainer.Address1
+                    ^ca_entities.AddressContainer.Address2
+                    ^ca_entities.AddressContainer.TownCity
+                    ^ca_entities.AddressContainer.State
+                    ^ca_entities.AddressContainer.PostCode</pre>
+                  </td>
+                  <tr><th>Phone</th><td>^Phone</td></tr>
+                  <tr><th>Mobile</th> <td> ^MobilePhone</td></tr>
+                  <tr><th>Fax</th><td>^Fax</td></tr>
+                  <tr><th>Email</th><td>^Email</td></tr>
+                  <tr><th>Notes</th><td>^DonorNotes</td></tr>
+                  <tr><th>Deceased</th><td>^Deceased</td></tr>
+                  <tr><th>Donor agent name</th><td>^DonorAgentName</td></tr>
+                  <tr><th>Donor agent's address</th><td> ^DonorAgentAddress</td></tr>
+                  <tr><th>Donor agent's Phone</th><td>^DonorAgentPhone</td></tr>
+                  </table>
+                  ]]></setting>
               </settings>
             </placement>
             <placement code="ca_attribute_ReceiptNum">

--- a/rwahs.xml
+++ b/rwahs.xml
@@ -1485,24 +1485,60 @@
                 <setting name="label" locale="en_AU">Source / Donor</setting>
                 <setting name="restrictToRelationshipTypes">donor</setting>
                 <setting name="display_template"><![CDATA[
-                <table class="table-bordered">
-                  <tr><th>Donor Name<l></th><td><l>^preferred_labels</l>(^type_id)</td></tr>
-                  <tr><th>Address</th>
-                  <td><pre>^ca_entities.AddressContainer.Address1
+                  <table class="table-bordered">
+                    <tr>
+                      <th>Donor Name
+                        <l>
+                      </th>
+                      <td>
+                        <l>^preferred_labels</l>
+                        (^type_id)
+                      </td>
+                    </tr>
+                    <tr>
+                      <th>Address</th>
+                      <td><pre>^ca_entities.AddressContainer.Address1
                     ^ca_entities.AddressContainer.Address2
                     ^ca_entities.AddressContainer.TownCity
                     ^ca_entities.AddressContainer.State
                     ^ca_entities.AddressContainer.PostCode</pre>
-                  </td>
-                  <tr><th>Phone</th><td>^Phone</td></tr>
-                  <tr><th>Mobile</th> <td> ^MobilePhone</td></tr>
-                  <tr><th>Fax</th><td>^Fax</td></tr>
-                  <tr><th>Email</th><td>^Email</td></tr>
-                  <tr><th>Notes</th><td>^DonorNotes</td></tr>
-                  <tr><th>Deceased</th><td>^Deceased</td></tr>
-                  <tr><th>Donor agent name</th><td>^DonorAgentName</td></tr>
-                  <tr><th>Donor agent's address</th><td> ^DonorAgentAddress</td></tr>
-                  <tr><th>Donor agent's Phone</th><td>^DonorAgentPhone</td></tr>
+                      </td>
+                    <tr>
+                      <th>Phone</th>
+                      <td>^Phone</td>
+                    </tr>
+                    <tr>
+                      <th>Mobile</th>
+                      <td> ^MobilePhone</td>
+                    </tr>
+                    <tr>
+                      <th>Fax</th>
+                      <td>^Fax</td>
+                    </tr>
+                    <tr>
+                      <th>Email</th>
+                      <td>^Email</td>
+                    </tr>
+                    <tr>
+                      <th>Notes</th>
+                      <td>^DonorNotes</td>
+                    </tr>
+                    <tr>
+                      <th>Deceased</th>
+                      <td>^Deceased</td>
+                    </tr>
+                    <tr>
+                      <th>Donor agent name</th>
+                      <td>^DonorAgentName</td>
+                    </tr>
+                    <tr>
+                      <th>Donor agent's address</th>
+                      <td> ^DonorAgentAddress</td>
+                    </tr>
+                    <tr>
+                      <th>Donor agent's Phone</th>
+                      <td>^DonorAgentPhone</td>
+                    </tr>
                   </table>
                   ]]></setting>
               </settings>

--- a/rwahs.xml
+++ b/rwahs.xml
@@ -1100,6 +1100,21 @@
             <placement code="ca_attribute_Email">
               <bundle>ca_attribute_Email</bundle>
             </placement>
+            <placement code="ca_attribute_DonorNotes">
+              <bundle>ca_attribute_DonorNotes</bundle>
+            </placement>
+            <placement code="ca_attribute_Deceased">
+              <bundle>ca_attribute_Deceased</bundle>
+            </placement>
+            <placement code="ca_attribute_DonorAgentName">
+              <bundle>ca_attribute_DonorAgentName</bundle>
+            </placement>
+            <placement code="ca_attribute_DonorAgentAddress">
+              <bundle>ca_attribute_DonorAgentAddress</bundle>
+            </placement>
+            <placement code="ca_attribute_DonorAgentPhone">
+              <bundle>ca_attribute_DonorAgentPhone</bundle>
+            </placement>
           </bundlePlacements>
         </screen>
         <screen idno="altnames" default="0">

--- a/rwahs.xml
+++ b/rwahs.xml
@@ -1483,8 +1483,13 @@
               <bundle>ca_entities</bundle>
               <settings>
                 <setting name="label" locale="en_AU">Source / Donor</setting>
-                <setting name="restrictToRelationshipTypes">donor</setting>
+                <setting name="restrict_to_relationship_types">donor</setting>
                 <setting name="list_format">list</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">1</setting>
+                <setting name="maxRelationshipsPerRow">1</setting>
+                <setting name="showCurrentOnly">0</setting>
                 <setting name="display_template"><![CDATA[
                   <dl>
                     <dt>Donor Name:

--- a/rwahs.xml
+++ b/rwahs.xml
@@ -413,10 +413,124 @@
         </item>
       </items>
     </list>
+    <list code="yesNoDefaultNo" hierarchical="0" system="1" vocabulary="0" defaultSort="1">
+      <labels>
+        <label locale="en_AU">
+          <name>Yes   No list</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="yes" enabled="1" default="0" value="1">
+          <labels>
+            <label locale="en_AU" preferred="1">
+              <name_singular>Yes</name_singular>
+              <name_plural>Yes</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="no" enabled="1" default="0" value="0">
+          <labels>
+            <label locale="en_AU" preferred="1">
+              <name_singular>No</name_singular>
+              <name_plural>No</name_plural>
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="yesNoDefaultYes" hierarchical="0" system="1" vocabulary="0" defaultSort="1">
+      <labels>
+        <label locale="en_AU">
+          <name>Yes   No list</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="yes" enabled="1" default="1" value="0">
+          <labels>
+            <label locale="en_AU" preferred="1">
+              <name_singular>Yes</name_singular>
+              <name_plural>Yes</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="no" enabled="1" default="0" value="1">
+          <labels>
+            <label locale="en_AU" preferred="1">
+              <name_singular>No</name_singular>
+              <name_plural>No</name_plural>
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
   </lists>
   <elementSets>
     <!--Basic Elements-->
-    <metadataElement code="description" datatype="Text">
+    <metadataElement code="LastEditBy" datatype="Text">
+      <labels>
+        <label locale="en_AU">
+          <name>Last Edited By</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="usewysiwygeditor">0</setting>
+        <setting name="fieldWidth">70</setting>
+        <setting name="fieldHeight">6</setting>
+        <setting name="minChars">0</setting>
+        <setting name="maxChars">30</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction code="objects">
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction code="entities">
+          <table>ca_entities</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="LastEditDate" datatype="DateRange">
+      <labels>
+        <label locale="en_AU">
+          <name>Last Edit Date</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="usewysiwygeditor">0</setting>
+        <setting name="fieldWidth">70</setting>
+        <setting name="fieldHeight">6</setting>
+        <setting name="minChars">0</setting>
+        <setting name="maxChars">30</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction code="objects">
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction code="entities">
+          <table>ca_entities</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="Description" datatype="Text">
       <labels>
         <label locale="en_AU">
           <name>Description</name>
@@ -491,7 +605,7 @@
         </restriction>
       </typeRestrictions>
     </metadataElement>
-    <metadataElement code="itemType" datatype="List" list="itemTypes">
+    <metadataElement code="ItemType" datatype="List" list="itemTypes">
       <labels>
         <label locale="en_AU">
           <name>Item Type</name>
@@ -512,7 +626,7 @@
         </restriction>
       </typeRestrictions>
     </metadataElement>
-    <metadataElement code="legacyId" datatype="Integer">
+    <metadataElement code="LegacyID" datatype="Integer">
       <labels>
         <label locale="en_AU">
           <name>Legacy Identifier</name>
@@ -529,324 +643,8 @@
         </restriction>
       </typeRestrictions>
     </metadataElement>
-    <metadataElement code="description_source" datatype="Text">
-      <labels>
-        <label locale="en_AU">
-          <name>Source of description</name>
-          <description>Source of item description. This should be a formal citation if possible. For informal sources a narrative description is acceptable.</description>
-        </label>
-      </labels>
-      <settings>
-        <setting name="fieldWidth">640px</setting>
-        <setting name="fieldHeight">3</setting>
-        <setting name="minChars">0</setting>
-        <setting name="maxChars">65535</setting>
-      </settings>
-      <typeRestrictions>
-        <restriction code="r1">
-          <table>ca_objects</table>
-          <settings>
-            <setting name="minAttributesPerRow">0</setting>
-            <setting name="maxAttributesPerRow">100</setting>
-            <setting name="minimumAttributeBundlesToDisplay">1</setting>
-          </settings>
-        </restriction>
-        <restriction code="r2">
-          <table>ca_places</table>
-          <settings>
-            <setting name="minAttributesPerRow">0</setting>
-            <setting name="maxAttributesPerRow">100</setting>
-            <setting name="minimumAttributeBundlesToDisplay">1</setting>
-          </settings>
-        </restriction>
-        <restriction code="r3">
-          <table>ca_occurrences</table>
-          <type>event</type>
-          <settings>
-            <setting name="minAttributesPerRow">0</setting>
-            <setting name="maxAttributesPerRow">100</setting>
-            <setting name="minimumAttributeBundlesToDisplay">1</setting>
-          </settings>
-        </restriction>
-        <restriction code="r4">
-          <table>ca_collections</table>
-          <settings>
-            <setting name="minAttributesPerRow">0</setting>
-            <setting name="maxAttributesPerRow">100</setting>
-            <setting name="minimumAttributeBundlesToDisplay">1</setting>
-          </settings>
-        </restriction>
-        <restriction code="r5">
-          <table>ca_storage_locations</table>
-          <settings>
-            <setting name="minAttributesPerRow">0</setting>
-            <setting name="maxAttributesPerRow">100</setting>
-            <setting name="minimumAttributeBundlesToDisplay">1</setting>
-          </settings>
-        </restriction>
-        <restriction code="r6">
-          <table>ca_object_lots</table>
-          <settings>
-            <setting name="minAttributesPerRow">0</setting>
-            <setting name="maxAttributesPerRow">100</setting>
-            <setting name="minimumAttributeBundlesToDisplay">1</setting>
-          </settings>
-        </restriction>
-      </typeRestrictions>
-    </metadataElement>
-    <metadataElement code="date" datatype="Container">
-      <labels>
-        <label locale="en_AU">
-          <name>Date</name>
-          <description>A point or period of time associated with an event in the life cycle of the resource.</description>
-        </label>
-      </labels>
-      <documentationUrl>http://dublincore.org/documents/dcmi-terms/#terms-date</documentationUrl>
-      <elements>
-        <metadataElement code="dates_value" datatype="DateRange">
-          <labels>
-            <label locale="en_AU">
-              <name>Date</name>
-            </label>
-          </labels>
-          <settings>
-            <setting name="fieldWidth">40</setting>
-            <setting name="fieldHeight">1</setting>
-            <setting name="minChars">0</setting>
-            <setting name="maxChars">65535</setting>
-          </settings>
-        </metadataElement>
-        <metadataElement code="dc_dates_types" datatype="List" list="date_types">
-          <labels>
-            <label locale="en_AU">
-              <name>Type</name>
-            </label>
-          </labels>
-          <settings>
-            <setting name="fieldWidth">40</setting>
-          </settings>
-        </metadataElement>
-      </elements>
-      <typeRestrictions>
-        <restriction code="objects">
-          <table>ca_objects</table>
-          <settings>
-            <setting name="minAttributesPerRow">0</setting>
-            <setting name="maxAttributesPerRow">255</setting>
-            <setting name="minimumAttributeBundlesToDisplay">1</setting>
-          </settings>
-        </restriction>
-        <restriction code="r1">
-          <table>ca_object_representations</table>
-          <settings>
-            <setting name="minAttributesPerRow">0</setting>
-            <setting name="maxAttributesPerRow">1</setting>
-            <setting name="minimumAttributeBundlesToDisplay">1</setting>
-          </settings>
-        </restriction>
-      </typeRestrictions>
-    </metadataElement>
-    <metadataElement code="coverageDates" datatype="DateRange">
-      <labels>
-        <label locale="en_AU">
-          <name>Coverage Dates</name>
-        </label>
-      </labels>
-      <documentationUrl>http://dublincore.org/documents/dcmi-terms/#terms-coverage</documentationUrl>
-      <settings>
-        <setting name="fieldWidth">40</setting>
-        <setting name="fieldHeight">1</setting>
-        <setting name="minChars">0</setting>
-        <setting name="maxChars">65535</setting>
-      </settings>
-      <typeRestrictions>
-        <restriction code="r1">
-          <table>ca_objects</table>
-          <settings>
-            <setting name="minAttributesPerRow">0</setting>
-            <setting name="maxAttributesPerRow">1</setting>
-            <setting name="minimumAttributeBundlesToDisplay">1</setting>
-          </settings>
-        </restriction>
-        <restriction code="r2">
-          <table>ca_object_representations</table>
-          <settings>
-            <setting name="minAttributesPerRow">0</setting>
-            <setting name="maxAttributesPerRow">1</setting>
-            <setting name="minimumAttributeBundlesToDisplay">1</setting>
-          </settings>
-        </restriction>
-      </typeRestrictions>
-    </metadataElement>
-    <metadataElement code="dimensions" datatype="Container">
-      <labels>
-        <label locale="en_AU">
-          <name>Dimensions</name>
-        </label>
-      </labels>
-      <elements>
-        <metadataElement code="dimensions_length" datatype="Length">
-          <labels>
-            <label locale="en_AU">
-              <name>Length</name>
-              <description>Length of object; enter in your preferred units (eg. 10cm)</description>
-            </label>
-          </labels>
-          <settings>
-            <setting name="fieldWidth">10</setting>
-            <setting name="fieldHeight">1</setting>
-          </settings>
-        </metadataElement>
-        <metadataElement code="dimensions_width" datatype="Length">
-          <labels>
-            <label locale="en_AU">
-              <name>Width</name>
-              <description>Width of object; enter in your preferred units (eg. 10cm)</description>
-            </label>
-          </labels>
-          <settings>
-            <setting name="fieldWidth">10</setting>
-            <setting name="fieldHeight">1</setting>
-          </settings>
-        </metadataElement>
-        <metadataElement code="dimensions_height" datatype="Length">
-          <labels>
-            <label locale="en_AU">
-              <name>Height</name>
-              <description>Height of object; enter in your preferred units (eg. 10cm)</description>
-            </label>
-          </labels>
-          <settings>
-            <setting name="fieldWidth">10</setting>
-            <setting name="fieldHeight">1</setting>
-          </settings>
-        </metadataElement>
-        <metadataElement code="dimensions_thickness" datatype="Length">
-          <labels>
-            <label locale="en_AU">
-              <name>Thickness</name>
-              <description>Thickness of object; enter in your preferred units (eg. 10cm)</description>
-            </label>
-          </labels>
-          <settings>
-            <setting name="fieldWidth">10</setting>
-            <setting name="fieldHeight">1</setting>
-          </settings>
-        </metadataElement>
-        <metadataElement code="dimensions_weight" datatype="Weight">
-          <labels>
-            <label locale="en_AU">
-              <name>Weight</name>
-              <description>Weight of object; enter in your preferred units</description>
-            </label>
-          </labels>
-          <settings>
-            <setting name="fieldWidth">10</setting>
-            <setting name="fieldHeight">1</setting>
-          </settings>
-        </metadataElement>
-        <metadataElement code="meas_line1" datatype="Container">
-          <labels>
-            <label locale="en_AU">
-              <name>Line 1</name>
-            </label>
-          </labels>
-          <elements>
-            <metadataElement code="measurement_notes" datatype="Text">
-              <labels>
-                <label locale="en_AU">
-                  <name>Measurement Notes</name>
-                </label>
-              </labels>
-              <settings>
-                <setting name="fieldWidth">70</setting>
-                <setting name="fieldHeight">2</setting>
-                <setting name="minChars">0</setting>
-                <setting name="maxChars">65535</setting>
-              </settings>
-            </metadataElement>
-          </elements>
-        </metadataElement>
-      </elements>
-      <typeRestrictions>
-        <restriction code="r1">
-          <table>ca_objects</table>
-          <type>image</type>
-          <settings>
-            <setting name="minAttributesPerRow">0</setting>
-            <setting name="maxAttributesPerRow">1</setting>
-            <setting name="minimumAttributeBundlesToDisplay">1</setting>
-          </settings>
-        </restriction>
-        <restriction code="r3">
-          <table>ca_objects</table>
-          <type>physical_object</type>
-          <settings>
-            <setting name="minAttributesPerRow">0</setting>
-            <setting name="maxAttributesPerRow">1</setting>
-            <setting name="minimumAttributeBundlesToDisplay">1</setting>
-          </settings>
-        </restriction>
-      </typeRestrictions>
-    </metadataElement>
-    <!--Subject Elements-->
-    <metadataElement code="lcsh_terms" datatype="LCSH">
-      <labels>
-        <label locale="en_AU">
-          <name>Library of Congress Subject Headings</name>
-          <description>Library of Congress Subject headings describing this object. To add a new heading simply type the first few letters of the heading and choose the desired one from the displayed list of possible matches.</description>
-        </label>
-      </labels>
-      <documentationUrl>http://dublincore.org/documents/dcmi-terms/#terms-subject</documentationUrl>
-      <settings>
-        <setting name="fieldWidth">500px</setting>
-        <setting name="fieldHeight">1</setting>
-      </settings>
-      <typeRestrictions>
-        <restriction code="ca_objects">
-          <table>ca_objects</table>
-          <settings>
-            <setting name="minAttributesPerRow">0</setting>
-            <setting name="maxAttributesPerRow">100</setting>
-            <setting name="minimumAttributeBundlesToDisplay">1</setting>
-          </settings>
-        </restriction>
-        <restriction code="ca_entities">
-          <table>ca_entities</table>
-          <settings>
-            <setting name="minAttributesPerRow">0</setting>
-            <setting name="maxAttributesPerRow">100</setting>
-            <setting name="minimumAttributeBundlesToDisplay">1</setting>
-          </settings>
-        </restriction>
-        <restriction code="ca_places">
-          <table>ca_places</table>
-          <settings>
-            <setting name="minAttributesPerRow">0</setting>
-            <setting name="maxAttributesPerRow">100</setting>
-            <setting name="minimumAttributeBundlesToDisplay">1</setting>
-          </settings>
-        </restriction>
-        <restriction code="ca_occurrences">
-          <table>ca_occurrences</table>
-          <settings>
-            <setting name="minAttributesPerRow">0</setting>
-            <setting name="maxAttributesPerRow">100</setting>
-            <setting name="minimumAttributeBundlesToDisplay">1</setting>
-          </settings>
-        </restriction>
-        <restriction code="ca_collections">
-          <table>ca_collections</table>
-          <settings>
-            <setting name="minAttributesPerRow">0</setting>
-            <setting name="maxAttributesPerRow">100</setting>
-            <setting name="minimumAttributeBundlesToDisplay">1</setting>
-          </settings>
-        </restriction>
-      </typeRestrictions>
-    </metadataElement>
     <!--Entity Elements-->
-    <metadataElement code="address" datatype="Container">
+    <metadataElement code="AddressContainer" datatype="Container">
       <labels>
         <label locale="en_AU">
           <name>Address</name>
@@ -856,7 +654,7 @@
         <setting name="doesNotTakeLocale">1</setting>
       </settings>
       <elements>
-        <metadataElement code="line1" datatype="Container">
+        <metadataElement code="Line1" datatype="Container">
           <labels>
             <label locale="en_AU">
               <name>Address line 1</name>
@@ -864,7 +662,7 @@
           </labels>
           <settings/>
           <elements>
-            <metadataElement code="address1" datatype="Text">
+            <metadataElement code="Address1" datatype="Text">
               <labels>
                 <label locale="en_AU">
                   <name>Address line 1</name>
@@ -879,7 +677,7 @@
             </metadataElement>
           </elements>
         </metadataElement>
-        <metadataElement code="line2" datatype="Container">
+        <metadataElement code="Line2" datatype="Container">
           <labels>
             <label locale="en_AU">
               <name>Address line 1</name>
@@ -887,7 +685,7 @@
           </labels>
           <settings/>
           <elements>
-            <metadataElement code="address2" datatype="Text">
+            <metadataElement code="Address2" datatype="Text">
               <labels>
                 <label locale="en_AU">
                   <name>Address line 2</name>
@@ -902,7 +700,7 @@
             </metadataElement>
           </elements>
         </metadataElement>
-        <metadataElement code="line3" datatype="Container">
+        <metadataElement code="Line3" datatype="Container">
           <labels>
             <label locale="en_AU">
               <name>Address line 3</name>
@@ -910,7 +708,7 @@
           </labels>
           <settings/>
           <elements>
-            <metadataElement code="city" datatype="Text">
+            <metadataElement code="TownCity" datatype="Text">
               <labels>
                 <label locale="en_AU">
                   <name>City</name>
@@ -921,9 +719,10 @@
                 <setting name="fieldHeight">1</setting>
                 <setting name="minChars">0</setting>
                 <setting name="maxChars">255</setting>
+                <setting name="suggetExistingValues">1</setting>
               </settings>
             </metadataElement>
-            <metadataElement code="stateprovince" datatype="Text">
+            <metadataElement code="State" datatype="Text">
               <labels>
                 <label locale="en_AU">
                   <name>State/province</name>
@@ -934,9 +733,10 @@
                 <setting name="fieldHeight">1</setting>
                 <setting name="minChars">0</setting>
                 <setting name="maxChars">255</setting>
+                <setting name="suggetExistingValues">1</setting>
               </settings>
             </metadataElement>
-            <metadataElement code="postalcode" datatype="Text">
+            <metadataElement code="PostCode" datatype="Text">
               <labels>
                 <label locale="en_AU">
                   <name>Postal/zip code</name>
@@ -947,9 +747,10 @@
                 <setting name="fieldHeight">1</setting>
                 <setting name="minChars">0</setting>
                 <setting name="maxChars">255</setting>
+                <setting name="suggetExistingValues">1</setting>
               </settings>
             </metadataElement>
-            <metadataElement code="country" datatype="Text">
+            <metadataElement code="Country" datatype="Text">
               <labels>
                 <label locale="en_AU">
                   <name>Country</name>
@@ -960,6 +761,7 @@
                 <setting name="fieldHeight">1</setting>
                 <setting name="minChars">0</setting>
                 <setting name="maxChars">255</setting>
+                <setting name="suggetExistingValues">1</setting>
               </settings>
             </metadataElement>
           </elements>
@@ -984,17 +786,17 @@
         </restriction>
       </typeRestrictions>
     </metadataElement>
-    <metadataElement code="telephone" datatype="Text">
+    <metadataElement code="Phone" datatype="Text">
       <labels>
         <label locale="en_AU">
-          <name>Telephone/fax</name>
+          <name>Phone</name>
         </label>
       </labels>
       <settings>
         <setting name="fieldWidth">70</setting>
         <setting name="fieldHeight">1</setting>
         <setting name="minChars">0</setting>
-        <setting name="maxChars">65535</setting>
+        <setting name="maxChars">30</setting>
         <setting name="doesNotTakeLocale">1</setting>
       </settings>
       <typeRestrictions>
@@ -1002,21 +804,37 @@
           <table>ca_entities</table>
           <settings>
             <setting name="minAttributesPerRow">0</setting>
-            <setting name="maxAttributesPerRow">10</setting>
-            <setting name="minimumAttributeBundlesToDisplay">1</setting>
-          </settings>
-        </restriction>
-        <restriction code="ca_places">
-          <table>ca_places</table>
-          <settings>
-            <setting name="minAttributesPerRow">0</setting>
-            <setting name="maxAttributesPerRow">10</setting>
+            <setting name="maxAttributesPerRow">3</setting>
             <setting name="minimumAttributeBundlesToDisplay">1</setting>
           </settings>
         </restriction>
       </typeRestrictions>
     </metadataElement>
-    <metadataElement code="email" datatype="Text">
+    <metadataElement code="MobilePhone" datatype="Text">
+      <labels>
+        <label locale="en_AU">
+          <name>Mobile Phone</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">70</setting>
+        <setting name="fieldHeight">1</setting>
+        <setting name="minChars">0</setting>
+        <setting name="maxChars">30</setting>
+        <setting name="doesNotTakeLocale">1</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction code="ca_entities">
+          <table>ca_entities</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="Email" datatype="Text">
       <labels>
         <label locale="en_AU">
           <name>Email address</name>
@@ -1026,7 +844,7 @@
         <setting name="fieldWidth">70</setting>
         <setting name="fieldHeight">1</setting>
         <setting name="minChars">0</setting>
-        <setting name="maxChars">65535</setting>
+        <setting name="maxChars">255</setting>
         <setting name="doesNotTakeLocale">1</setting>
       </settings>
       <typeRestrictions>
@@ -1034,7 +852,7 @@
           <table>ca_entities</table>
           <settings>
             <setting name="minAttributesPerRow">0</setting>
-            <setting name="maxAttributesPerRow">10</setting>
+            <setting name="maxAttributesPerRow">1</setting>
             <setting name="minimumAttributeBundlesToDisplay">1</setting>
           </settings>
         </restriction>
@@ -1042,27 +860,27 @@
           <table>ca_places</table>
           <settings>
             <setting name="minAttributesPerRow">0</setting>
-            <setting name="maxAttributesPerRow">10</setting>
+            <setting name="maxAttributesPerRow">1</setting>
             <setting name="minimumAttributeBundlesToDisplay">1</setting>
           </settings>
         </restriction>
       </typeRestrictions>
     </metadataElement>
-    <metadataElement code="biography" datatype="Text">
+    <metadataElement code="DonorNotes" datatype="Text">
       <labels>
         <label locale="en_AU">
-          <name>Description</name>
-          <description>Narrative biography for entity. This is the primary text used to document the entity.</description>
+          <name>Notes</name>
         </label>
       </labels>
       <settings>
         <setting name="fieldWidth">70</setting>
-        <setting name="fieldHeight">6</setting>
+        <setting name="fieldHeight">1</setting>
         <setting name="minChars">0</setting>
-        <setting name="maxChars">65535</setting>
+        <setting name="maxChars">255</setting>
+        <setting name="doesNotTakeLocale">1</setting>
       </settings>
       <typeRestrictions>
-        <restriction code="r1">
+        <restriction code="ca_entities">
           <table>ca_entities</table>
           <settings>
             <setting name="minAttributesPerRow">1</setting>
@@ -1072,26 +890,95 @@
         </restriction>
       </typeRestrictions>
     </metadataElement>
-    <metadataElement code="biography_source" datatype="Text">
+    <metadataElement code="Deceased" datatype="List" list="yesNoDefaultNo">
       <labels>
         <label locale="en_AU">
-          <name>Source of description</name>
-          <description>Source of entity biography. This should be a formal citation if possible. For informal sources a narrative description is acceptable.</description>
+          <name>Deceased</name>
         </label>
       </labels>
       <settings>
-        <setting name="fieldWidth">70</setting>
-        <setting name="fieldHeight">3</setting>
-        <setting name="minChars">0</setting>
-        <setting name="maxChars">65535</setting>
+        <setting name="render">yes_no_checkboxes</setting>
+        <setting name="doesNotTakeLocale">1</setting>
       </settings>
       <typeRestrictions>
-        <restriction code="r1">
+        <restriction code="ca_entities">
           <table>ca_entities</table>
           <settings>
             <setting name="minAttributesPerRow">1</setting>
             <setting name="maxAttributesPerRow">1</setting>
             <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="DonorAgentName" datatype="Text">
+      <labels>
+        <label locale="en_AU">
+          <name>Donor Agent Name</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">70</setting>
+        <setting name="fieldHeight">1</setting>
+        <setting name="minChars">0</setting>
+        <setting name="maxChars">255</setting>
+        <setting name="doesNotTakeLocale">1</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction code="ca_entities">
+          <table>ca_entities</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">0</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="DonorAgentAddress" datatype="Text">
+      <labels>
+        <label locale="en_AU">
+          <name>Donor Agent's Address</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">70</setting>
+        <setting name="fieldHeight">1</setting>
+        <setting name="minChars">0</setting>
+        <setting name="maxChars">255</setting>
+        <setting name="doesNotTakeLocale">1</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction code="ca_entities">
+          <table>ca_entities</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">0</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="DonorAgentPhone" datatype="Text">
+      <labels>
+        <label locale="en_AU">
+          <name>Donor Agent's Phone Number</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">70</setting>
+        <setting name="fieldHeight">1</setting>
+        <setting name="minChars">0</setting>
+        <setting name="maxChars">30</setting>
+        <setting name="doesNotTakeLocale">1</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction code="ca_entities">
+          <table>ca_entities</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">0</setting>
           </settings>
         </restriction>
       </typeRestrictions>
@@ -1119,8 +1006,8 @@
             </label>
           </labels>
           <bundlePlacements>
-            <placement code="ca_attribute_itemType">
-              <bundle>ca_attribute_itemType</bundle>
+            <placement code="ca_attribute_ItemType">
+              <bundle>ca_attribute_ItemType</bundle>
             </placement>
             <placement code="idno">
               <bundle>idno</bundle>
@@ -1150,8 +1037,8 @@
             </label>
           </labels>
           <bundlePlacements>
-            <placement code="ca_attribute_itemType">
-              <bundle>ca_attribute_itemType</bundle>
+            <placement code="ca_attribute_ItemType">
+              <bundle>ca_attribute_ItemType</bundle>
             </placement>
             <placement code="idno">
               <bundle>idno</bundle>
@@ -1168,8 +1055,8 @@
             </label>
           </labels>
           <bundlePlacements>
-            <placement code="ca_attribute_itemType">
-              <bundle>ca_attribute_itemType</bundle>
+            <placement code="ca_attribute_ItemType">
+              <bundle>ca_attribute_ItemType</bundle>
             </placement>
             <placement code="idno">
               <bundle>idno</bundle>
@@ -1188,10 +1075,10 @@
         </label>
       </labels>
       <screens>
-        <screen idno="s1" default="1">
+        <screen idno="donorData" default="1">
           <labels>
             <label locale="en_AU">
-              <name>Basic Info</name>
+              <name>Donor Data</name>
             </label>
           </labels>
           <bundlePlacements>
@@ -1201,14 +1088,17 @@
             <placement code="preferred_labels">
               <bundle>preferred_labels</bundle>
             </placement>
-            <placement code="ca_attribute_biography">
-              <bundle>ca_attribute_biography</bundle>
+            <placement code="ca_attribute_AddressContainer">
+              <bundle>ca_attribute_AddressContainer</bundle>
             </placement>
-            <placement code="ca_attribute_biography_source">
-              <bundle>ca_attribute_biography_source</bundle>
+            <placement code="ca_attribute_Phone">
+              <bundle>ca_attribute_Phone</bundle>
             </placement>
-            <placement code="ca_attribute_internal_notes">
-              <bundle>ca_attribute_internal_notes</bundle>
+            <placement code="ca_attribute_MobilePhone">
+              <bundle>ca_attribute_MobilePhone</bundle>
+            </placement>
+            <placement code="ca_attribute_Email">
+              <bundle>ca_attribute_Email</bundle>
             </placement>
           </bundlePlacements>
         </screen>
@@ -1225,24 +1115,6 @@
                 <setting name="label" locale="en_AU">Alternate names</setting>
                 <setting name="add_label" locale="en_AU">Add name</setting>
               </settings>
-            </placement>
-          </bundlePlacements>
-        </screen>
-        <screen idno="contact" default="0">
-          <labels>
-            <label locale="en_AU">
-              <name>Contact info</name>
-            </label>
-          </labels>
-          <bundlePlacements>
-            <placement code="ca_attribute_address">
-              <bundle>ca_attribute_address</bundle>
-            </placement>
-            <placement code="ca_attribute_telephone">
-              <bundle>ca_attribute_telephone</bundle>
-            </placement>
-            <placement code="ca_attribute_email">
-              <bundle>ca_attribute_email</bundle>
             </placement>
           </bundlePlacements>
         </screen>

--- a/rwahs.xml
+++ b/rwahs.xml
@@ -1484,61 +1484,62 @@
               <settings>
                 <setting name="label" locale="en_AU">Source / Donor</setting>
                 <setting name="restrictToRelationshipTypes">donor</setting>
+                <setting name="list_format">list</setting>
                 <setting name="display_template"><![CDATA[
-                  <table class="table-bordered">
-                    <tr>
-                      <th>Donor Name
-                      </th>
-                      <td>
-                        <l>^preferred_labels</l>
-                        (^type_id)
-                      </td>
-                    </tr>
-                    <tr>
-                      <th>Address</th>
-                      <td><pre>^ca_entities.AddressContainer.Address1
-                    ^ca_entities.AddressContainer.Address2
-                    ^ca_entities.AddressContainer.TownCity
-                    ^ca_entities.AddressContainer.State
-                    ^ca_entities.AddressContainer.PostCode</pre>
-                      </td>
-                    <tr>
-                      <th>Phone</th>
-                      <td>^Phone</td>
-                    </tr>
-                    <tr>
-                      <th>Mobile</th>
-                      <td> ^MobilePhone</td>
-                    </tr>
-                    <tr>
-                      <th>Fax</th>
-                      <td>^Fax</td>
-                    </tr>
-                    <tr>
-                      <th>Email</th>
-                      <td>^Email</td>
-                    </tr>
-                    <tr>
-                      <th>Notes</th>
-                      <td>^DonorNotes</td>
-                    </tr>
-                    <tr>
-                      <th>Deceased</th>
-                      <td>^Deceased</td>
-                    </tr>
-                    <tr>
-                      <th>Donor agent name</th>
-                      <td>^DonorAgentName</td>
-                    </tr>
-                    <tr>
-                      <th>Donor agent's address</th>
-                      <td> ^DonorAgentAddress</td>
-                    </tr>
-                    <tr>
-                      <th>Donor agent's Phone</th>
-                      <td>^DonorAgentPhone</td>
-                    </tr>
-                  </table>
+                  <dl>
+                    <dt>Donor Name:
+                    </dt>
+                    <dd>
+                      <l><strong>^ca_entities.preferred_labels.displayname</strong> (^ca_entities.type_id)</l>
+                    </dd>
+                    <ifdef code="ca_entities.AddressContainer">
+                      <dt>Address:</dt>
+                      <dd>
+                        <ifdef code="ca_entities.AddressContainer.Address1">^ca_entities.AddressContainer.Address1<br/></ifdef>
+                        <ifdef code="ca_entities.AddressContainer.Address2">^ca_entities.AddressContainer.Address2<br/></ifdef>
+                        <ifdef code="ca_entities.AddressContainer.TownCity">^ca_entities.AddressContainer.TownCity<br/></ifdef>
+                        <ifdef code="ca_entities.AddressContainer.State">^ca_entities.AddressContainer.State<br/></ifdef>
+                        <ifdef code="ca_entities.AddressContainer.PostCode">^ca_entities.AddressContainer.PostCode</ifdef>
+                        <ifdef code="ca_entities.AddressContainer.Country">^ca_entities.AddressContainer.Country</ifdef>
+                      </dd>
+                    </ifdef>
+                    <ifdef code="ca_entities.Phone">
+                      <dt>Phone:</dt>
+                      <dd>^ca_entities.Phone</dd>
+                    </ifdef>
+                    <ifdef code="ca_entities.MobilePhone">
+                      <dt>Mobile:</dt>
+                      <dd>^ca_entities.MobilePhone</dd>
+                    </ifdef>
+                    <ifdef code="ca_entities.Fax">
+                      <dt>Fax:</dt>
+                      <dd>^ca_entities.Fax</dd>
+                    </ifdef>
+                    <ifdef code="ca_entities.Email">
+                      <dt>Email:</dt>
+                      <dd>^ca_entities.Email</dd>
+                    </ifdef>
+                    <ifdef code="ca_entities.DonorNotes">
+                      <dt>Notes:</dt>
+                      <dd>^ca_entities.DonorNotes</dd>
+                    </ifdef>
+                    <ifdef code="ca_entities.Deceased">
+                      <dt>Deceased:</dt>
+                      <dd>^ca_entities.Deceased</dd>
+                    </ifdef>
+                    <ifdef code="ca_entities.DonorAgentName">
+                      <dt>Donor agent name:</dt>
+                      <dd>^ca_entities.DonorAgentName</dd>
+                    </ifdef>
+                    <ifdef code="ca_entities.DonorAgentAddress">
+                      <dt>Donor agent's address:</dt>
+                      <dd>^ca_entities.DonorAgentAddress</dd>
+                    </ifdef>
+                    <ifdef code="ca_entities.DonorAgentPhone">
+                      <dt>Donor agent's Phone:</dt>
+                      <dd>^ca_entities.DonorAgentPhone</dd>
+                    </ifdef>
+                  </dl>
                   ]]></setting>
               </settings>
             </placement>

--- a/rwahs.xml
+++ b/rwahs.xml
@@ -1240,7 +1240,6 @@
         </restriction>
       </typeRestrictions>
     </metadataElement>
-
     <metadataElement code="Correspondence" datatype="Text">
       <labels>
         <label locale="en_AU">
@@ -1305,14 +1304,12 @@
                 <setting name="add_label" locale="en_AU">Add name</setting>
               </settings>
             </placement>
-
             <placement code="ca_entities_donor">
               <bundle>ca_entities</bundle>
               <settings>
                 <setting name="label" locale="en_AU">Source / Donor</setting>
                 <setting name="restrictToTypes">donor</setting>
               </settings>
-
             </placement>
             <placement code="ca_attribute_ReceiptNum">
               <bundle>ca_attribute_ReceiptNum</bundle>
@@ -1403,6 +1400,9 @@
             </placement>
             <placement code="ca_attribute_Phone">
               <bundle>ca_attribute_Phone</bundle>
+            </placement>
+            <placement code="ca_attribute_Fax">
+              <bundle>ca_attribute_Fax</bundle>
             </placement>
             <placement code="ca_attribute_MobilePhone">
               <bundle>ca_attribute_MobilePhone</bundle>

--- a/rwahs.xml
+++ b/rwahs.xml
@@ -1422,7 +1422,7 @@
         </label>
       </labels>
       <settings>
-        <setting name="fieldWidth">450</setting>
+        <setting name="fieldWidth">115</setting>
         <setting name="fieldHeight">4</setting>
         <setting name="minChars">0</setting>
         <setting name="usewysiwygeditor">1</setting>
@@ -1483,7 +1483,7 @@
               <bundle>ca_entities</bundle>
               <settings>
                 <setting name="label" locale="en_AU">Source / Donor</setting>
-                <setting name="restrictToTypes">donor</setting>
+                <setting name="restrictToRelationshipTypes">donor</setting>
               </settings>
             </placement>
             <placement code="ca_attribute_ReceiptNum">

--- a/rwahs.xml
+++ b/rwahs.xml
@@ -877,6 +877,14 @@
             <setting name="minimumAttributeBundlesToDisplay">0</setting>
           </settings>
         </restriction>
+        <restriction code="r2">
+          <table>ca_entities</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">0</setting>
+          </settings>
+        </restriction>
       </typeRestrictions>
     </metadataElement>
     <!--Entity Elements-->

--- a/rwahs.xml
+++ b/rwahs.xml
@@ -79,7 +79,7 @@
             </label>
           </labels>
         </item>
-        <item idno="photo" enabled="1" default="0">
+        <item idno="photograph" enabled="1" default="0">
           <labels>
             <label locale="en_AU" preferred="1">
               <name_singular>Photograph</name_singular>
@@ -508,6 +508,23 @@
             <setting name="minAttributesPerRow">1</setting>
             <setting name="maxAttributesPerRow">1</setting>
             <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="legacyId" datatype="Integer">
+      <labels>
+        <label locale="en_AU">
+          <name>Legacy Identifier</name>
+        </label>
+      </labels>
+      <typeRestrictions>
+        <restriction code="r1">
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">0</setting>
           </settings>
         </restriction>
       </typeRestrictions>
@@ -1109,6 +1126,13 @@
               <bundle>idno</bundle>
               <settings>
                 <setting name="label" locale="en_AU">Accession ID</setting>
+              </settings>
+            </placement>
+            <placement code="preferred_labels">
+              <bundle>preferred_labels</bundle>
+              <settings>
+                <setting name="label" locale="en_AU">Item Name</setting>
+                <setting name="add_label" locale="en_AU">Add name</setting>
               </settings>
             </placement>
             <placement code="acquisition_type_id">

--- a/rwahs.xml
+++ b/rwahs.xml
@@ -695,6 +695,173 @@
         </restriction>
       </typeRestrictions>
     </metadataElement>
+    <metadataElement code="AccessionPrefix" datatype="Text">
+      <labels>
+        <label locale="en_AU">
+          <name>Accession Prefix</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="usewysiwygeditor">0</setting>
+        <setting name="fieldWidth">10</setting>
+        <setting name="fieldHeight">6</setting>
+        <setting name="minChars">0</setting>
+        <setting name="maxChars">4</setting>
+        <setting name="doesNotTakeLocale">1</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction code="r1">
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">0</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="AccessionYear" datatype="Text">
+      <labels>
+        <label locale="en_AU">
+          <name>Accession Year</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="usewysiwygeditor">0</setting>
+        <setting name="fieldWidth">10</setting>
+        <setting name="fieldHeight">6</setting>
+        <setting name="minChars">0</setting>
+        <setting name="maxChars">4</setting>
+        <setting name="doesNotTakeLocale">1</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction code="r1">
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">0</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="AccessionNumber" datatype="Text">
+      <labels>
+        <label locale="en_AU">
+          <name>AccessionNumber</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="usewysiwygeditor">0</setting>
+        <setting name="fieldWidth">10</setting>
+        <setting name="fieldHeight">6</setting>
+        <setting name="minChars">0</setting>
+        <setting name="maxChars">255</setting>
+        <setting name="doesNotTakeLocale">1</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction code="r1">
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">0</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="AccessionSeries" datatype="Text">
+      <labels>
+        <label locale="en_AU">
+          <name>AccessionSeries</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="usewysiwygeditor">0</setting>
+        <setting name="fieldWidth">10</setting>
+        <setting name="fieldHeight">6</setting>
+        <setting name="minChars">0</setting>
+        <setting name="maxChars">255</setting>
+        <setting name="doesNotTakeLocale">1</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction code="r1">
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">0</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="AccessionParts" datatype="Text">
+      <labels>
+        <label locale="en_AU">
+          <name>AccessionParts</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="usewysiwygeditor">0</setting>
+        <setting name="fieldWidth">10</setting>
+        <setting name="fieldHeight">6</setting>
+        <setting name="minChars">0</setting>
+        <setting name="maxChars">255</setting>
+        <setting name="doesNotTakeLocale">1</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction code="r1">
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">0</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="AccessionBy" datatype="Text">
+      <labels>
+        <label locale="en_AU">
+          <name>AccessionBy</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="usewysiwygeditor">0</setting>
+        <setting name="fieldWidth">10</setting>
+        <setting name="fieldHeight">6</setting>
+        <setting name="minChars">0</setting>
+        <setting name="maxChars">30</setting>
+        <setting name="doesNotTakeLocale">1</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction code="r1">
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">0</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="AccessionDate" datatype="DateRange">
+      <labels>
+        <label locale="en_AU">
+          <name>AccessionDate</name>
+        </label>
+      </labels>
+      <typeRestrictions>
+        <restriction code="r1">
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">0</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
     <metadataElement code="LegacyID" datatype="Integer">
       <labels>
         <label locale="en_AU">

--- a/rwahs.xml
+++ b/rwahs.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><profile xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="profile.xsd" useForConfiguration="1" base="base_en_AU" infoUrl="https://github.com/rwahs/providence">
+<?xml version="1.0" encoding="UTF-8"?>
+<profile xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="profile.xsd"
+         useForConfiguration="1" base="base_en_AU" infoUrl="https://github.com/rwahs/providence">
   <profileName>RWAHS - Royal Western Australian Historical Society</profileName>
   <profileDescription>Royal Western Australian Historical Society profile</profileDescription>
   <locales>
@@ -98,51 +100,67 @@
       </items>
     </list>
     <list code="object_acq_types" hierarchical="0" system="1" vocabulary="0">
-      <labels><label locale="en_AU">
-        <name>Object acquisition types</name>
-      </label></labels>
+      <labels>
+        <label locale="en_AU">
+          <name>Object acquisition types</name>
+        </label>
+      </labels>
       <items>
         <item idno="bequest" enabled="1" default="1">
-          <labels><label locale="en_AU" preferred="1">
-            <name_singular>Bequest</name_singular>
-            <name_plural>Bequests</name_plural>
-          </label></labels>
+          <labels>
+            <label locale="en_AU" preferred="1">
+              <name_singular>Bequest</name_singular>
+              <name_plural>Bequests</name_plural>
+            </label>
+          </labels>
         </item>
         <item idno="donation" enabled="1" default="0">
-          <labels><label locale="en_AU" preferred="1">
-            <name_singular>Donation</name_singular>
-            <name_plural>Donations</name_plural>
-          </label></labels>
+          <labels>
+            <label locale="en_AU" preferred="1">
+              <name_singular>Donation</name_singular>
+              <name_plural>Donations</name_plural>
+            </label>
+          </labels>
         </item>
         <item idno="internal" enabled="1" default="0">
-          <labels><label locale="en_AU" preferred="1">
-            <name_singular>Internal</name_singular>
-            <name_plural>Internal</name_plural>
-          </label></labels>
+          <labels>
+            <label locale="en_AU" preferred="1">
+              <name_singular>Internal</name_singular>
+              <name_plural>Internal</name_plural>
+            </label>
+          </labels>
         </item>
         <item idno="purchase" enabled="1" default="0">
-          <labels><label locale="en_AU" preferred="1">
-            <name_singular>Purchase</name_singular>
-            <name_plural>Purchases</name_plural>
-          </label></labels>
+          <labels>
+            <label locale="en_AU" preferred="1">
+              <name_singular>Purchase</name_singular>
+              <name_plural>Purchases</name_plural>
+            </label>
+          </labels>
         </item>
         <item idno="salvage" enabled="1" default="0">
-          <labels><label locale="en_AU" preferred="1">
-            <name_singular>Salvage</name_singular>
-            <name_plural>Salvage</name_plural>
-          </label></labels>
+          <labels>
+            <label locale="en_AU" preferred="1">
+              <name_singular>Salvage</name_singular>
+              <name_plural>Salvage</name_plural>
+            </label>
+          </labels>
         </item>
         <item idno="unknown" enabled="1" default="0">
-          <labels><label locale="en_AU" preferred="1">
-            <name_singular>Unknown</name_singular>
-            <name_plural>Unknown</name_plural>
-          </label></labels>
+          <labels>
+            <label locale="en_AU" preferred="1">
+              <name_singular>Unknown</name_singular>
+              <name_plural>Unknown</name_plural>
+            </label>
+          </labels>
         </item>
         <item idno="other" enabled="1" default="0">
-          <labels><label locale="en_AU" preferred="1">
-            <name_singular>Other</name_singular>
-            <name_plural>Other</name_plural>
-          </label></labels>
+          <labels>
+            <label locale="en_AU" preferred="1">
+              <name_singular>Other</name_singular>
+              <name_plural>Other</name_plural>
+            </label>
+          </labels>
         </item>
       </items>
     </list>
@@ -416,7 +434,7 @@
     <list code="yesNoDefaultNo" hierarchical="0" system="1" vocabulary="0" defaultSort="1">
       <labels>
         <label locale="en_AU">
-          <name>Yes   No list</name>
+          <name>Yes No list with Default of No</name>
         </label>
       </labels>
       <items>
@@ -441,7 +459,7 @@
     <list code="yesNoDefaultYes" hierarchical="0" system="1" vocabulary="0" defaultSort="1">
       <labels>
         <label locale="en_AU">
-          <name>Yes   No list</name>
+          <name>Yes No list with Default of Yes</name>
         </label>
       </labels>
       <items>
@@ -458,6 +476,55 @@
             <label locale="en_AU" preferred="1">
               <name_singular>No</name_singular>
               <name_plural>No</name_plural>
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="conditionOnReceipt" hierarchical="0" system="1" vocabulary="0">
+      <labels>
+        <label locale="en_AU">
+          <name>Condition on Receipt</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="excellent" enabled="1" default="1" value="5">
+          <labels>
+            <label locale="en_AU" preferred="1">
+              <name_singular>Excellent</name_singular>
+              <name_plural>Excellent</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="good" enabled="1" default="0" value="4">
+          <labels>
+            <label locale="en_AU" preferred="1">
+              <name_singular>Good</name_singular>
+              <name_plural>Good</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="fair_used" enabled="1" default="0" value="3">
+          <labels>
+            <label locale="en_AU" preferred="1">
+              <name_singular>Fair / Used</name_singular>
+              <name_plural>Fair / Used</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="damaged" enabled="1" default="0" value="2">
+          <labels>
+            <label locale="en_AU" preferred="1">
+              <name_singular>Damaged</name_singular>
+              <name_plural>Damaged</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="poor" enabled="1" default="0" value="1">
+          <labels>
+            <label locale="en_AU" preferred="1">
+              <name_singular>Damaged</name_singular>
+              <name_plural>Damaged</name_plural>
             </label>
           </labels>
         </item>
@@ -534,7 +601,9 @@
       <labels>
         <label locale="en_AU">
           <name>Description</name>
-          <description>An account of the resource. Description may include but is not limited to: an abstract, a table of contents, a graphical representation, or a free-text account of the resource.</description>
+          <description>An account of the resource. Description may include but is not limited to: an abstract, a table
+            of contents, a graphical representation, or a free-text account of the resource.
+          </description>
         </label>
       </labels>
       <documentationUrl>http://dublincore.org/documents/dcmi-terms/#terms-description</documentationUrl>
@@ -834,6 +903,30 @@
         </restriction>
       </typeRestrictions>
     </metadataElement>
+    <metadataElement code="Fax" datatype="Text">
+      <labels>
+        <label locale="en_AU">
+          <name>Fax</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">70</setting>
+        <setting name="fieldHeight">1</setting>
+        <setting name="minChars">0</setting>
+        <setting name="maxChars">30</setting>
+        <setting name="doesNotTakeLocale">1</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction code="ca_entities">
+          <table>ca_entities</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
     <metadataElement code="Email" datatype="Text">
       <labels>
         <label locale="en_AU">
@@ -983,6 +1076,196 @@
         </restriction>
       </typeRestrictions>
     </metadataElement>
+    <metadataElement code="ReceiptNum" datatype="Text">
+      <labels>
+        <label locale="en_AU">
+          <name>Receipt Number</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">70</setting>
+        <setting name="fieldHeight">1</setting>
+        <setting name="minChars">0</setting>
+        <setting name="maxChars">30</setting>
+        <setting name="doesNotTakeLocale">1</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction code="ca_objects">
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="DateReceived" datatype="DateRange">
+      <labels>
+        <label locale="en_AU">
+          <name>Date Received</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="suggestExistingValues">1</setting>
+        <setting name="suggestExistingValuesSort">recent</setting>
+        <setting name="useDatePicker">1</setting>
+        <setting name="doesNotTakeLocale">1</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction code="ca_objects">
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="ConditionOnReceipt" datatype="List" list="conditionOnReceipt">
+      <labels>
+        <label locale="en_AU">
+          <name>Condition (on receipt)</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="nullOptionText">Not Set</setting>
+        <setting name="render">select</setting>
+        <setting name="doesNotTakeLocale">1</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction code="ca_objects">
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="LegalTitle" datatype="Container">
+      <labels>
+        <label locale="en_AU">
+          <name>Legal Title?</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="render">yes_no_checkboxes</setting>
+        <setting name="doesNotTakeLocale">1</setting>
+      </settings>
+      <elements>
+        <metadataElement code="LegalTitleYesNo" datatype="List" list="yesNoDefaultNo">
+          <labels>
+            <label locale="en_AU">
+              <name>Legal Title?</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="render">yes_no_checkboxes</setting>
+            <setting name="doesNotTakeLocale">1</setting>
+          </settings>
+        </metadataElement>
+        <metadataElement code="TitleDetails" datatype="Text">
+          <labels>
+            <label locale="en_AU">
+              <name>Title Details</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="fieldWidth">70</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">255</setting>
+            <setting name="doesNotTakeLocale">1</setting>
+          </settings>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction code="ca_objects">
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="Copyright" datatype="Container">
+      <labels>
+        <label locale="en_AU">
+          <name>Copyright</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="doesNotTakeLocale">1</setting>
+      </settings>
+      <elements>
+        <metadataElement code="CopyrightYesNo" datatype="List" list="yesNoDefaultNo">
+          <labels>
+            <label locale="en_AU">
+              <name>Copyright?</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="render">yes_no_checkboxes</setting>
+            <setting name="doesNotTakeLocale">1</setting>
+          </settings>
+        </metadataElement>
+        <metadataElement code="CopyrightDetails" datatype="Text">
+          <labels>
+            <label locale="en_AU">
+              <name>Copyright Details</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="fieldWidth">70</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">255</setting>
+            <setting name="doesNotTakeLocale">1</setting>
+          </settings>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction code="ca_objects">
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+
+    <metadataElement code="Correspondence" datatype="Text">
+      <labels>
+        <label locale="en_AU">
+          <name>Correspondence</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">450</setting>
+        <setting name="fieldHeight">4</setting>
+        <setting name="minChars">0</setting>
+        <setting name="usewysiwygeditor">1</setting>
+        <setting name="maxChars">65535</setting>
+        <setting name="doesNotTakeLocale">1</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction code="ca_objects">
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
   </elementSets>
   <userInterfaces>
     <userInterface code="museum_object_ui" type="ca_objects">
@@ -1022,11 +1305,38 @@
                 <setting name="add_label" locale="en_AU">Add name</setting>
               </settings>
             </placement>
+
+            <placement code="ca_entities_donor">
+              <bundle>ca_entities</bundle>
+              <settings>
+                <setting name="label" locale="en_AU">Source / Donor</setting>
+                <setting name="restrictToTypes">donor</setting>
+              </settings>
+
+            </placement>
+            <placement code="ca_attribute_ReceiptNum">
+              <bundle>ca_attribute_ReceiptNum</bundle>
+            </placement>
             <placement code="acquisition_type_id">
               <bundle>acquisition_type_id</bundle>
               <settings>
                 <setting name="label" locale="en_AU">Method of Acquisition</setting>
               </settings>
+            </placement>
+            <placement code="ca_attribute_DateReceived">
+              <bundle>ca_attribute_DateReceived</bundle>
+            </placement>
+            <placement code="ca_attribute_ConditionOnReceipt">
+              <bundle>ca_attribute_ConditionOnReceipt</bundle>
+            </placement>
+            <placement code="ca_attribute_LegalTitle">
+              <bundle>ca_attribute_LegalTitle</bundle>
+            </placement>
+            <placement code="ca_attribute_Copyright">
+              <bundle>ca_attribute_Copyright</bundle>
+            </placement>
+            <placement code="ca_attribute_Correspondence">
+              <bundle>ca_attribute_Correspondence</bundle>
             </placement>
           </bundlePlacements>
         </screen>
@@ -1858,7 +2168,7 @@
               <typename_reverse>is donor of</typename_reverse>
             </label>
           </labels>
-          <subTypeLeft> </subTypeLeft>
+          <subTypeLeft></subTypeLeft>
           <subTypeRight></subTypeRight>
         </type>
         <type code="creator" default="1">
@@ -1868,7 +2178,7 @@
               <typename_reverse>creator</typename_reverse>
             </label>
           </labels>
-          <subTypeLeft> </subTypeLeft>
+          <subTypeLeft></subTypeLeft>
           <subTypeRight></subTypeRight>
         </type>
         <type code="publisher" default="0">
@@ -1878,7 +2188,7 @@
               <typename_reverse>publisher</typename_reverse>
             </label>
           </labels>
-          <subTypeLeft> </subTypeLeft>
+          <subTypeLeft></subTypeLeft>
           <subTypeRight></subTypeRight>
         </type>
         <type code="contributor" default="0">
@@ -1888,7 +2198,7 @@
               <typename_reverse>contributor</typename_reverse>
             </label>
           </labels>
-          <subTypeLeft> </subTypeLeft>
+          <subTypeLeft></subTypeLeft>
           <subTypeRight></subTypeRight>
         </type>
         <type code="source" default="0">
@@ -1898,7 +2208,7 @@
               <typename_reverse>source</typename_reverse>
             </label>
           </labels>
-          <subTypeLeft> </subTypeLeft>
+          <subTypeLeft></subTypeLeft>
           <subTypeRight></subTypeRight>
         </type>
       </types>
@@ -1912,7 +2222,7 @@
               <typename_reverse>is depicted by</typename_reverse>
             </label>
           </labels>
-          <subTypeLeft> </subTypeLeft>
+          <subTypeLeft></subTypeLeft>
           <subTypeRight>event</subTypeRight>
         </type>
         <type code="used" default="0">
@@ -1922,7 +2232,7 @@
               <typename_reverse>used</typename_reverse>
             </label>
           </labels>
-          <subTypeLeft> </subTypeLeft>
+          <subTypeLeft></subTypeLeft>
           <subTypeRight>event</subTypeRight>
         </type>
         <type code="describes" default="0">
@@ -1932,7 +2242,7 @@
               <typename_reverse>is described by</typename_reverse>
             </label>
           </labels>
-          <subTypeLeft> </subTypeLeft>
+          <subTypeLeft></subTypeLeft>
           <subTypeRight></subTypeRight>
         </type>
       </types>
@@ -1946,7 +2256,7 @@
               <typename_reverse>contains</typename_reverse>
             </label>
           </labels>
-          <subTypeLeft> </subTypeLeft>
+          <subTypeLeft></subTypeLeft>
           <subTypeRight></subTypeRight>
         </type>
       </types>
@@ -1960,7 +2270,7 @@
               <typename_reverse>is related to</typename_reverse>
             </label>
           </labels>
-          <subTypeLeft> </subTypeLeft>
+          <subTypeLeft></subTypeLeft>
           <subTypeRight></subTypeRight>
         </type>
         <type code="source" default="0">
@@ -1970,7 +2280,7 @@
               <typename_reverse>is source of</typename_reverse>
             </label>
           </labels>
-          <subTypeLeft> </subTypeLeft>
+          <subTypeLeft></subTypeLeft>
           <subTypeRight></subTypeRight>
         </type>
         <type code="duplicate" default="0">
@@ -1980,7 +2290,7 @@
               <typename_reverse>is duplicate of</typename_reverse>
             </label>
           </labels>
-          <subTypeLeft> </subTypeLeft>
+          <subTypeLeft></subTypeLeft>
           <subTypeRight></subTypeRight>
         </type>
         <type code="part_of" default="0">
@@ -1990,7 +2300,7 @@
               <typename_reverse>contains</typename_reverse>
             </label>
           </labels>
-          <subTypeLeft> </subTypeLeft>
+          <subTypeLeft></subTypeLeft>
           <subTypeRight></subTypeRight>
         </type>
       </types>
@@ -2032,7 +2342,7 @@
               <typename_reverse>was creation location of</typename_reverse>
             </label>
           </labels>
-          <subTypeLeft> </subTypeLeft>
+          <subTypeLeft></subTypeLeft>
           <subTypeRight></subTypeRight>
         </type>
         <type code="located" default="0">
@@ -2052,7 +2362,7 @@
               <typename_reverse>is depicted by</typename_reverse>
             </label>
           </labels>
-          <subTypeLeft> </subTypeLeft>
+          <subTypeLeft></subTypeLeft>
           <subTypeRight></subTypeRight>
         </type>
         <type code="describes" default="0">
@@ -2062,7 +2372,7 @@
               <typename_reverse>is described by</typename_reverse>
             </label>
           </labels>
-          <subTypeLeft> </subTypeLeft>
+          <subTypeLeft></subTypeLeft>
           <subTypeRight></subTypeRight>
         </type>
       </types>
@@ -2076,7 +2386,7 @@
               <typename_reverse>describes</typename_reverse>
             </label>
           </labels>
-          <subTypeLeft> </subTypeLeft>
+          <subTypeLeft></subTypeLeft>
           <subTypeRight></subTypeRight>
         </type>
         <type code="depicts" default="0">
@@ -2086,7 +2396,7 @@
               <typename_reverse>is depicted by</typename_reverse>
             </label>
           </labels>
-          <subTypeLeft> </subTypeLeft>
+          <subTypeLeft></subTypeLeft>
           <subTypeRight></subTypeRight>
         </type>
       </types>
@@ -2100,7 +2410,7 @@
               <typename_reverse>is related to</typename_reverse>
             </label>
           </labels>
-          <subTypeLeft> </subTypeLeft>
+          <subTypeLeft></subTypeLeft>
           <subTypeRight></subTypeRight>
         </type>
       </types>
@@ -2114,7 +2424,7 @@
               <typename_reverse>was birthplace of</typename_reverse>
             </label>
           </labels>
-          <subTypeLeft> </subTypeLeft>
+          <subTypeLeft></subTypeLeft>
           <subTypeRight></subTypeRight>
         </type>
         <type code="residence" default="0">
@@ -2124,7 +2434,7 @@
               <typename_reverse>was residence of</typename_reverse>
             </label>
           </labels>
-          <subTypeLeft> </subTypeLeft>
+          <subTypeLeft></subTypeLeft>
           <subTypeRight></subTypeRight>
         </type>
         <type code="workplace" default="0">
@@ -2134,7 +2444,7 @@
               <typename_reverse>was workplace of</typename_reverse>
             </label>
           </labels>
-          <subTypeLeft> </subTypeLeft>
+          <subTypeLeft></subTypeLeft>
           <subTypeRight></subTypeRight>
         </type>
         <type code="ownership" default="0">
@@ -2144,7 +2454,7 @@
               <typename_reverse>was owned by</typename_reverse>
             </label>
           </labels>
-          <subTypeLeft> </subTypeLeft>
+          <subTypeLeft></subTypeLeft>
           <subTypeRight></subTypeRight>
         </type>
         <type code="built_by" default="0">
@@ -2154,7 +2464,7 @@
               <typename_reverse>was built by</typename_reverse>
             </label>
           </labels>
-          <subTypeLeft> </subTypeLeft>
+          <subTypeLeft></subTypeLeft>
           <subTypeRight></subTypeRight>
         </type>
       </types>
@@ -2168,7 +2478,7 @@
               <typename_reverse>was attended by</typename_reverse>
             </label>
           </labels>
-          <subTypeLeft> </subTypeLeft>
+          <subTypeLeft></subTypeLeft>
           <subTypeRight>event</subTypeRight>
         </type>
       </types>
@@ -2182,7 +2492,7 @@
               <typename_reverse>is provider of</typename_reverse>
             </label>
           </labels>
-          <subTypeLeft> </subTypeLeft>
+          <subTypeLeft></subTypeLeft>
           <subTypeRight></subTypeRight>
         </type>
       </types>
@@ -2196,7 +2506,7 @@
               <typename_reverse>is origination location of</typename_reverse>
             </label>
           </labels>
-          <subTypeLeft> </subTypeLeft>
+          <subTypeLeft></subTypeLeft>
           <subTypeRight></subTypeRight>
         </type>
       </types>
@@ -2210,7 +2520,7 @@
               <typename_reverse>contains</typename_reverse>
             </label>
           </labels>
-          <subTypeLeft> </subTypeLeft>
+          <subTypeLeft></subTypeLeft>
           <subTypeRight></subTypeRight>
         </type>
       </types>
@@ -2224,7 +2534,7 @@
               <typename_reverse>is related to</typename_reverse>
             </label>
           </labels>
-          <subTypeLeft> </subTypeLeft>
+          <subTypeLeft></subTypeLeft>
           <subTypeRight></subTypeRight>
         </type>
       </types>
@@ -2238,7 +2548,7 @@
               <typename_reverse>describes</typename_reverse>
             </label>
           </labels>
-          <subTypeLeft> </subTypeLeft>
+          <subTypeLeft></subTypeLeft>
           <subTypeRight></subTypeRight>
         </type>
       </types>
@@ -2252,7 +2562,7 @@
               <typename_reverse>describes</typename_reverse>
             </label>
           </labels>
-          <subTypeLeft> </subTypeLeft>
+          <subTypeLeft></subTypeLeft>
           <subTypeRight></subTypeRight>
         </type>
       </types>
@@ -2266,7 +2576,7 @@
               <typename_reverse>is related to</typename_reverse>
             </label>
           </labels>
-          <subTypeLeft> </subTypeLeft>
+          <subTypeLeft></subTypeLeft>
           <subTypeRight></subTypeRight>
         </type>
       </types>
@@ -2280,7 +2590,7 @@
               <typename_reverse>describes</typename_reverse>
             </label>
           </labels>
-          <subTypeLeft> </subTypeLeft>
+          <subTypeLeft></subTypeLeft>
           <subTypeRight></subTypeRight>
         </type>
       </types>
@@ -2294,7 +2604,7 @@
               <typename_reverse>describes</typename_reverse>
             </label>
           </labels>
-          <subTypeLeft> </subTypeLeft>
+          <subTypeLeft></subTypeLeft>
           <subTypeRight></subTypeRight>
         </type>
       </types>
@@ -2308,7 +2618,7 @@
               <typename_reverse>occurred at</typename_reverse>
             </label>
           </labels>
-          <subTypeLeft> </subTypeLeft>
+          <subTypeLeft></subTypeLeft>
           <subTypeRight>event</subTypeRight>
         </type>
       </types>
@@ -2322,7 +2632,7 @@
               <typename_reverse>is related to</typename_reverse>
             </label>
           </labels>
-          <subTypeLeft> </subTypeLeft>
+          <subTypeLeft></subTypeLeft>
           <subTypeRight></subTypeRight>
         </type>
       </types>
@@ -2336,7 +2646,7 @@
               <typename_reverse>describes</typename_reverse>
             </label>
           </labels>
-          <subTypeLeft> </subTypeLeft>
+          <subTypeLeft></subTypeLeft>
           <subTypeRight></subTypeRight>
         </type>
       </types>
@@ -2350,7 +2660,7 @@
               <typename_reverse>is located in</typename_reverse>
             </label>
           </labels>
-          <subTypeLeft> </subTypeLeft>
+          <subTypeLeft></subTypeLeft>
           <subTypeRight></subTypeRight>
         </type>
       </types>
@@ -2364,7 +2674,7 @@
               <typename_reverse>is related to</typename_reverse>
             </label>
           </labels>
-          <subTypeLeft> </subTypeLeft>
+          <subTypeLeft></subTypeLeft>
           <subTypeRight></subTypeRight>
         </type>
       </types>
@@ -2378,7 +2688,7 @@
               <typename_reverse>is depicted by</typename_reverse>
             </label>
           </labels>
-          <subTypeLeft> </subTypeLeft>
+          <subTypeLeft></subTypeLeft>
           <subTypeRight></subTypeRight>
         </type>
         <type code="illustrated" default="1">
@@ -2388,7 +2698,7 @@
               <typename_reverse>illustrates</typename_reverse>
             </label>
           </labels>
-          <subTypeLeft> </subTypeLeft>
+          <subTypeLeft></subTypeLeft>
           <subTypeRight></subTypeRight>
         </type>
       </types>
@@ -2402,7 +2712,7 @@
               <typename_reverse>is depicted by</typename_reverse>
             </label>
           </labels>
-          <subTypeLeft> </subTypeLeft>
+          <subTypeLeft></subTypeLeft>
           <subTypeRight></subTypeRight>
         </type>
         <type code="describes" default="1">
@@ -2412,7 +2722,7 @@
               <typename_reverse>is described by</typename_reverse>
             </label>
           </labels>
-          <subTypeLeft> </subTypeLeft>
+          <subTypeLeft></subTypeLeft>
           <subTypeRight></subTypeRight>
         </type>
       </types>
@@ -2426,7 +2736,7 @@
               <typename_reverse>is depicted by</typename_reverse>
             </label>
           </labels>
-          <subTypeLeft> </subTypeLeft>
+          <subTypeLeft></subTypeLeft>
           <subTypeRight></subTypeRight>
         </type>
         <type code="describes" default="1">
@@ -2436,7 +2746,7 @@
               <typename_reverse>is described by</typename_reverse>
             </label>
           </labels>
-          <subTypeLeft> </subTypeLeft>
+          <subTypeLeft></subTypeLeft>
           <subTypeRight></subTypeRight>
         </type>
       </types>
@@ -2450,7 +2760,7 @@
               <typename_reverse>is depicted by</typename_reverse>
             </label>
           </labels>
-          <subTypeLeft> </subTypeLeft>
+          <subTypeLeft></subTypeLeft>
           <subTypeRight>event</subTypeRight>
         </type>
         <type code="describes" default="1">
@@ -2460,7 +2770,7 @@
               <typename_reverse>is described by</typename_reverse>
             </label>
           </labels>
-          <subTypeLeft> </subTypeLeft>
+          <subTypeLeft></subTypeLeft>
           <subTypeRight>event</subTypeRight>
         </type>
       </types>
@@ -2474,7 +2784,7 @@
               <typename_reverse>describes</typename_reverse>
             </label>
           </labels>
-          <subTypeLeft> </subTypeLeft>
+          <subTypeLeft></subTypeLeft>
           <subTypeRight></subTypeRight>
         </type>
       </types>
@@ -2492,7 +2802,9 @@
     <group code="museum">
       <name>Museum</name>
       <description>Museum Users</description>
-      <roles><role>museum</role></roles>
+      <roles>
+        <role>museum</role>
+      </roles>
     </group>
   </groups>
   <displays>
@@ -2817,7 +3129,8 @@
   </searchForms>
 
   <logins>
-    <login user_name="administrator" password="administrator" fname="CollectiveAccess" lname="Administrator" email="administrator@rwahs.org.au">
+    <login user_name="administrator" password="administrator" fname="CollectiveAccess" lname="Administrator"
+           email="administrator@rwahs.org.au">
       <group code="admin"/>
     </login>
     <login user_name="museum" password="museum" fname="Museum" lname="User" email="museum@rwahs.org.au">

--- a/rwahs.xml
+++ b/rwahs.xml
@@ -1488,7 +1488,6 @@
                   <table class="table-bordered">
                     <tr>
                       <th>Donor Name
-                        <l>
                       </th>
                       <td>
                         <l>^preferred_labels</l>

--- a/rwahs.xml
+++ b/rwahs.xml
@@ -523,8 +523,8 @@
         <item idno="poor" enabled="1" default="0" value="1">
           <labels>
             <label locale="en_AU" preferred="1">
-              <name_singular>Damaged</name_singular>
-              <name_plural>Damaged</name_plural>
+              <name_singular>Poor</name_singular>
+              <name_plural>Poor</name_plural>
             </label>
           </labels>
         </item>


### PR DESCRIPTION
Changes to profile to support https://youtrack.gaiaresources.com.au/issue/RWAHS-35

Unfortunately the diff on the profile is too big for github, but this adds the fields to entities for acquisition import.
* Adds attributes to objects and entities to support the adminDonor data category in the import mapping spreadsheet (https://docs.google.com/spreadsheets/d/11ynTouvmgYI-RoesX3rbvi4xUAhiwTCsOcoUwGLqVHc/edit?usp=sharing)
* Adds a donor information screen to the entity editor.
* Adds extra fields to the Museum object UI