### PR TITLE
Add Public Memorials form and elements

### DIFF
--- a/profile/rwahs.xml
+++ b/profile/rwahs.xml
@@ -722,14 +722,16 @@
               <name_plural>Library</name_plural>
             </label>
           </labels>
-          <items><item idno="LargeBook" enabled="1" default="0">
-            <labels>
-              <label locale="en_AU" preferred="1">
-                <name_singular>Large Book</name_singular>
-                <name_plural>Large Book</name_plural>
-              </label>
-            </labels>
-          </item></items>
+          <items>
+            <item idno="LargeBook" enabled="1" default="0">
+              <labels>
+                <label locale="en_AU" preferred="1">
+                  <name_singular>Large Book</name_singular>
+                  <name_plural>Large Book</name_plural>
+                </label>
+              </labels>
+            </item>
+          </items>
         </item>
         <item idno="MapAnnex" enabled="1" default="0">
           <labels>
@@ -3807,6 +3809,16 @@
             <setting name="minimumAttributeBundlesToDisplay">1</setting>
           </settings>
         </restriction>
+        <restriction code="publicMemorial_Notes">
+          <table>ca_objects</table>
+          <type>publicMemorial</type>
+          <includeSubtypes>true</includeSubtypes>
+          <settings>
+            <setting name="minAttributesPerRow">1</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
       </typeRestrictions>
     </metadataElement>
     <metadataElement code="CopyNumber" datatype="Text">
@@ -4262,6 +4274,16 @@
             <setting name="minimumAttributeBundlesToDisplay">1</setting>
           </settings>
         </restriction>
+        <restriction code="publicMemorial_Creator">
+          <table>ca_objects</table>
+          <type>publicMemorial</type>
+          <includeSubtypes>true</includeSubtypes>
+          <settings>
+            <setting name="minAttributesPerRow">1</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
       </typeRestrictions>
     </metadataElement>
     <metadataElement code="DateOfCreation" datatype="DateRange">
@@ -4452,6 +4474,151 @@
         <restriction code="photograph_SpecificLocation">
           <table>ca_objects</table>
           <type>photograph</type>
+          <includeSubtypes>true</includeSubtypes>
+          <settings>
+            <setting name="minAttributesPerRow">1</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <!-- Public Memorial fields-->
+    <metadataElement code="Inscription" datatype="Text">
+      <labels>
+        <label locale="en_AU">
+          <name>Inscription</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="usewysiwygeditor">0</setting>
+        <setting name="fieldWidth">115</setting>
+        <setting name="fieldHeight">6</setting>
+        <setting name="suggestExistingValues">0</setting>
+        <setting name="minChars">0</setting>
+        <setting name="maxChars">16777215</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction code="publicMemorial_Inscription">
+          <table>ca_objects</table>
+          <type>publicMemorial</type>
+          <includeSubtypes>true</includeSubtypes>
+          <settings>
+            <setting name="minAttributesPerRow">1</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="ErectedBy" datatype="Text">
+      <labels>
+        <label locale="en_AU">
+          <name>ErectedBy</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="usewysiwygeditor">0</setting>
+        <setting name="fieldWidth">70</setting>
+        <setting name="fieldHeight">1</setting>
+        <setting name="suggestExistingValues">1</setting>
+        <setting name="minChars">0</setting>
+        <setting name="maxChars">255</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction code="publicMemorial_ErectedBy">
+          <table>ca_objects</table>
+          <type>publicMemorial</type>
+          <includeSubtypes>true</includeSubtypes>
+          <settings>
+            <setting name="minAttributesPerRow">1</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="Dates" datatype="Container">
+      <labels>
+        <label locale="en_AU">
+          <name>Dates</name>
+        </label>
+      </labels>
+      <elements>
+        <metadataElement code="Erection" datatype="DateRange">
+          <labels>
+            <label locale="en_AU">
+              <name>Date of erection</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="fieldWidth">20</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">30</setting>
+            <setting name="useDatePicker">1</setting>
+          </settings>
+        </metadataElement>
+        <metadataElement code="Creation" datatype="DateRange">
+          <labels>
+            <label locale="en_AU">
+              <name>Creation</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="fieldWidth">20</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">30</setting>
+            <setting name="useDatePicker">1</setting>
+          </settings>
+        </metadataElement>
+        <metadataElement code="Opening" datatype="DateRange">
+          <labels>
+            <label locale="en_AU">
+              <name>Opening of memorial</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="fieldWidth">20</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">30</setting>
+            <setting name="useDatePicker">1</setting>
+          </settings>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction code="publicMemorial_Dates">
+          <table>ca_objects</table>
+          <type>publicMemorial</type>
+          <includeSubtypes>true</includeSubtypes>
+          <settings>
+            <setting name="minAttributesPerRow">1</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="Provenance" datatype="Text">
+      <labels>
+        <label locale="en_AU">
+          <name>Provenance</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="usewysiwygeditor">0</setting>
+        <setting name="fieldWidth">115</setting>
+        <setting name="fieldHeight">6</setting>
+        <setting name="suggestExistingValues">0</setting>
+        <setting name="minChars">0</setting>
+        <setting name="maxChars">16777215</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction code="publicMemorial_Provenance">
+          <table>ca_objects</table>
+          <type>publicMemorial</type>
           <includeSubtypes>true</includeSubtypes>
           <settings>
             <setting name="minAttributesPerRow">1</setting>
@@ -5611,6 +5778,138 @@
             </placement>
             <placement code="access">
               <bundle>access</bundle>
+            </placement>
+          </bundlePlacements>
+        </screen>
+      </screens>
+    </userInterface>
+    <userInterface code="memorial_object_ui" type="ca_objects" system="0">
+      <labels>
+        <label locale="en_AU">
+          <name>Public Memorials object editor</name>
+        </label>
+      </labels>
+      <typeRestrictions>
+        <restriction type="publicMemorial"/>
+      </typeRestrictions>
+      <groupAccess>
+        <permission group="admin" access="edit"/>
+        <permission group="memorial" access="edit"/>
+      </groupAccess>
+      <screens>
+        <screen idno="memorial" default="1">
+          <labels>
+            <label locale="en_AU">
+              <name>Memorial Data</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="idno">
+              <bundle>idno</bundle>
+              <settings>
+                <setting name="label" locale="en_AU">Accession number</setting>
+              </settings>
+            </placement>
+            <placement code="preferred_labels">
+              <bundle>preferred_labels</bundle>
+              <settings>
+                <setting name="label" locale="en_AU">Item name</setting>
+                <setting name="add_label" locale="en_AU">Add item name</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_Description">
+              <bundle>ca_attribute_Description</bundle>
+            </placement>
+            <placement code="ca_attribute_Inscription">
+              <bundle>ca_attribute_Inscription</bundle>
+            </placement>
+            <placement code="ca_attribute_Creator">
+              <bundle>ca_attribute_Creator</bundle>
+            </placement>
+            <placement code="ca_attribute_ErectedBy">
+              <bundle>ca_attribute_ErectedBy</bundle>
+            </placement>
+            <placement code="ca_places">
+              <bundle>ca_places</bundle>
+              <settings>
+                <setting name="label" locale="en_AU">Geographical location of item</setting>
+                <setting name="restrict_to_relationship_types">located</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_Dates">
+              <bundle>ca_attribute_Dates</bundle>
+            </placement>
+            <placement code="subject">
+              <bundle>ca_occurrences</bundle>
+              <settings>
+                <setting name="label" locale="en_AU">Subject headings</setting>
+                <setting name="readonly"/>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="restrict_to_relationship_types">depicts</setting>
+                <setting name="restrict_to_relationship_types">used</setting>
+                <setting name="restrict_to_relationship_types">describes</setting>
+                <setting name="restrict_to_types">Event</setting>
+                <setting name="restrict_to_types">Organization</setting>
+                <setting name="restrict_to_types">Person</setting>
+                <setting name="restrict_to_types">Place</setting>
+                <setting name="restrict_to_types">Topic</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">list</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="display_template">
+                  <![CDATA[
+                  <dl>
+                    <dt>Subject:</dt>
+                    <dd>
+                      <unit relativeTo="ca_occurrences">
+                        <l>^preferred_labels</l>
+                      </unit>
+                    </dd>
+                    <ifdef code="ca_occurrences.SubjectDates">
+                      <dt>Subject Dates:</dt>
+                      <dd>^ca_occurrences.SubjectDates</dd>
+                    </ifdef>
+                    <dt>Type:</dt>
+                    <dd>^ca_occurrences.type_id</dd>
+                    <ifdef code="ca_occurrences.Description">
+                      <dt>Description:</dt>
+                      <dd>^ca_occurrences.Description</dd>
+                    </ifdef>
+                    <ifdef code="ca_objects_x_occurrences.Association">
+                      <dt>Association:</dt>
+                      <dd>^ca_objects_x_occurrences.Association</dd>
+                    </ifdef>
+                    <ifdef code="ca_objects_x_occurrences.SubjectDates">
+                      <dt>Dates:</dt>
+                      <dd>^ca_objects_x_occurrences.SubjectDates</dd>
+                    </ifdef>
+                  </dl>
+                  ]]>
+                </setting>
+                <setting name="minRelationshipsPerRow"/>
+                <setting name="maxRelationshipsPerRow">255</setting>
+                <setting name="showCurrentOnly">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_Materials">
+              <bundle>ca_attribute_Materials</bundle>
+            </placement>
+            <placement code="ca_attribute_Dimensions">
+              <bundle>ca_attribute_Dimensions</bundle>
+            </placement>
+            <placement code="ca_attribute_PhysicalCondition">
+              <bundle>ca_attribute_PhysicalCondition</bundle>
+            </placement>
+            <placement code="ca_attribute_Provenance">
+              <bundle>ca_attribute_Provenance</bundle>
+            </placement>
+            <placement code="ca_attribute_Notes">
+              <bundle>ca_attribute_Notes</bundle>
+            </placement>
+            <placement code="ca_object_representations">
+              <bundle>ca_object_representations</bundle>
             </placement>
           </bundlePlacements>
         </screen>
@@ -7183,6 +7482,11 @@
       <description>Photograph Users</description>
       <actions>
       </actions>
+    </role><role code="memorial">
+      <name>Public Memorial</name>
+      <description>Public Memorial Users</description>
+      <actions>
+      </actions>
     </role>
   </roles>
   <groups>
@@ -7207,6 +7511,14 @@
       <description>Photograph Users</description>
       <roles>
         <role>photograph</role>
+        <role>cataloguer</role>
+      </roles>
+    </group>
+    <group code="memorial">
+      <name>Public Memorial</name>
+      <description>Public Memorial Users</description>
+      <roles>
+        <role>memorial</role>
         <role>cataloguer</role>
       </roles>
     </group>
@@ -7545,8 +7857,14 @@
       <group code="library"/>
       <group code="cataloguer"/>
     </login>
-    <login user_name="photograph" password="photograph" fname="Photograph" lname="User" email="photograph@histwest.org.au">
+    <login user_name="photograph" password="photograph" fname="Photograph" lname="User"
+           email="photograph@histwest.org.au">
       <group code="photograph"/>
+      <group code="cataloguer"/>
+    </login>
+    <login user_name="memorial" password="memorial" fname="Memorial" lname="User"
+           email="memorial@histwest.org.au">
+      <group code="memorial"/>
       <group code="cataloguer"/>
     </login>
     <login user_name="researcher" password="researcher" fname="Researcher" lname="User"

--- a/profile/rwahs.xml
+++ b/profile/rwahs.xml
@@ -230,11 +230,11 @@
         </label>
       </labels>
       <items>
-        <item idno="dc" enabled="1" default="1">
+        <item idno="places" enabled="1" default="1">
           <labels>
             <label locale="en_AU" preferred="1">
-              <name_singular>DC Coverage Authority</name_singular>
-              <name_plural>DC Coverage Authorities</name_plural>
+              <name_singular>Place</name_singular>
+              <name_plural>Places</name_plural>
             </label>
           </labels>
         </item>

--- a/tests/Profile/ProfileACLTest.php
+++ b/tests/Profile/ProfileACLTest.php
@@ -7,19 +7,21 @@ class ProfileACLTest extends AbstractProfileTest
     public function testProfileContainsGroups()
     {
         $xpath = $this->xpath;
-        $this->assertEquals(3, $xpath->query('/profile/groups/group')->length, 'The number of groups should match');
+        $this->assertEquals(4, $xpath->query('/profile/groups/group')->length, 'The number of groups should match');
         $this->assertEquals(1, $xpath->query('/profile/groups/group[@code="museum"]')->length, 'The group with code "museum" should exist.');
         $this->assertEquals(1, $xpath->query('/profile/groups/group[@code="library"]')->length, 'The group with code "library" should exist.');
         $this->assertEquals(1, $xpath->query('/profile/groups/group[@code="photograph"]')->length, 'The group with code "photograph" should exist.');
+        $this->assertEquals(1, $xpath->query('/profile/groups/group[@code="memorial"]')->length, 'The group with code "memorial" should exist.');
     }
 
     public function testProfileContainsRoles()
     {
         $xpath = $this->xpath;
-        $this->assertEquals(3, $xpath->query('/profile/roles/role')->length, 'The number of roles should match');
+        $this->assertEquals(4, $xpath->query('/profile/roles/role')->length, 'The number of roles should match');
         $this->assertEquals(1, $xpath->query('/profile/roles/role[@code="museum"]')->length, 'The role with code "museum" should exist.');
         $this->assertEquals(1, $xpath->query('/profile/roles/role[@code="library"]')->length, 'The role with code "library" should exist.');
         $this->assertEquals(1, $xpath->query('/profile/roles/role[@code="photograph"]')->length, 'The role with code "photograph" should exist.');
+        $this->assertEquals(1, $xpath->query('/profile/roles/role[@code="memorial"]')->length, 'The role with code "memorial" should exist.');
     }
 
     public function testUIAccess()
@@ -28,14 +30,22 @@ class ProfileACLTest extends AbstractProfileTest
         $this->assertEquals(1, $xpath->query('/profile/userInterfaces/userInterface[@code="museum_object_ui"]/groupAccess/permission[@group="museum" and @access="edit"]')->length, 'The museum role should have edit access to the museum editor');
         $this->assertEquals(0, $xpath->query('/profile/userInterfaces/userInterface[@code="museum_object_ui"]/groupAccess/permission[@group="library" and @access="edit"]')->length, 'The library role should not have edit access to the museum editor');
         $this->assertEquals(0, $xpath->query('/profile/userInterfaces/userInterface[@code="museum_object_ui"]/groupAccess/permission[@group="photograph" and @access="edit"]')->length, 'The photograph role should not have edit access to the museum editor');
+        $this->assertEquals(0, $xpath->query('/profile/userInterfaces/userInterface[@code="museum_object_ui"]/groupAccess/permission[@group="memorial" and @access="edit"]')->length, 'The memorial role should not have edit access to the museum editor');
 
         $this->assertEquals(1, $xpath->query('/profile/userInterfaces/userInterface[@code="library_object_ui"]/groupAccess/permission[@group="library" and @access="edit"]')->length, 'The library role should have edit access to the library editor');
         $this->assertEquals(0, $xpath->query('/profile/userInterfaces/userInterface[@code="library_object_ui"]/groupAccess/permission[@group="museum" and @access="edit"]')->length, 'The museum role should not have edit access to the library editor');
         $this->assertEquals(0, $xpath->query('/profile/userInterfaces/userInterface[@code="library_object_ui"]/groupAccess/permission[@group="photograph" and @access="edit"]')->length, 'The photograph role should not have edit access to the library editor');
+        $this->assertEquals(0, $xpath->query('/profile/userInterfaces/userInterface[@code="library_object_ui"]/groupAccess/permission[@group="memorial" and @access="edit"]')->length, 'The memorial role should not have edit access to the library editor');
 
         $this->assertEquals(1, $xpath->query('/profile/userInterfaces/userInterface[@code="photograph_object_ui"]/groupAccess/permission[@group="photograph" and @access="edit"]')->length, 'The photograph role should have edit access to the photograph editor');
         $this->assertEquals(0, $xpath->query('/profile/userInterfaces/userInterface[@code="photograph_object_ui"]/groupAccess/permission[@group="museum" and @access="edit"]')->length, 'The museum role should not have edit access to the photograph editor');
         $this->assertEquals(0, $xpath->query('/profile/userInterfaces/userInterface[@code="photograph_object_ui"]/groupAccess/permission[@group="library" and @access="edit"]')->length, 'The library role should not have edit access to the photograph editor');
+        $this->assertEquals(0, $xpath->query('/profile/userInterfaces/userInterface[@code="photograph_object_ui"]/groupAccess/permission[@group="memorial" and @access="edit"]')->length, 'The memorial role should not have edit access to the photograph editor');
+
+        $this->assertEquals(1, $xpath->query('/profile/userInterfaces/userInterface[@code="memorial_object_ui"]/groupAccess/permission[@group="memorial" and @access="edit"]')->length, 'The memorial role should have edit access to the memorial editor');
+        $this->assertEquals(0, $xpath->query('/profile/userInterfaces/userInterface[@code="memorial_object_ui"]/groupAccess/permission[@group="museum" and @access="edit"]')->length, 'The museum role should not have edit access to the memorial editor');
+        $this->assertEquals(0, $xpath->query('/profile/userInterfaces/userInterface[@code="memorial_object_ui"]/groupAccess/permission[@group="library" and @access="edit"]')->length, 'The library role should not have edit access to the memorial editor');
+        $this->assertEquals(0, $xpath->query('/profile/userInterfaces/userInterface[@code="memorial_object_ui"]/groupAccess/permission[@group="photograph" and @access="edit"]')->length, 'The memorial role should not have edit access to the memorial editor');
     }
 
     public function testExampleUsersExist()

--- a/tests/Profile/ProfileElementTest.php
+++ b/tests/Profile/ProfileElementTest.php
@@ -114,4 +114,9 @@ LIST_XML
         }
     }
 
+    public function testContainersHaveElements()
+    {
+        $this->assertEquals(0, $this->xpath->query('/profile/elementSets//metadataElement[@datatype="Container" and not(elements/metadataElement)]')->length, 'Container elements require child elements');
+    }
+
 }

--- a/tests/Profile/ProfileUiTest.php
+++ b/tests/Profile/ProfileUiTest.php
@@ -10,10 +10,11 @@ class ProfileUiTest extends AbstractProfileTest
     public function testProfileContainsUis()
     {
         $xpath = $this->xpath;
-        $this->assertEquals(15, $xpath->query('/profile/userInterfaces/userInterface')->length, 'The number of user interfaces should match');
+        $this->assertEquals(16, $xpath->query('/profile/userInterfaces/userInterface')->length, 'The number of user interfaces should match');
         $this->assertEquals(1, $xpath->query('/profile/userInterfaces/userInterface[@code="museum_object_ui"]')->length, 'The user interface with code "museum_object_ui" should exist.');
         $this->assertEquals(1, $xpath->query('/profile/userInterfaces/userInterface[@code="library_object_ui"]')->length, 'The user interface with code "library_object_ui" should exist.');
         $this->assertEquals(1, $xpath->query('/profile/userInterfaces/userInterface[@code="photograph_object_ui"]')->length, 'The user interface with code "photograph_object_ui" should exist.');
+        $this->assertEquals(1, $xpath->query('/profile/userInterfaces/userInterface[@code="memorial_object_ui"]')->length, 'The user interface with code "memorial_object_ui" should exist.');
         $this->assertEquals(1, $xpath->query('/profile/userInterfaces/userInterface[@code="standard_entity_ui"]')->length, 'The user interface with code "standard_entity_ui" should exist.');
         $this->assertEquals(1, $xpath->query('/profile/userInterfaces/userInterface[@code="subject_list_ui"]')->length, 'The user interface with code "subject_list_ui" should exist.');
         $this->assertEquals(1, $xpath->query('/profile/userInterfaces/userInterface[@code="conservation_ui"]')->length, 'The user interface with code "conservation_ui" should exist.');


### PR DESCRIPTION
* Add tests for public memorial ui and roles
* Test to ensure that we don't define empty container attributes
* Add Public Memorial UI, group, roles and fields ￼…
 * Reformat `LargeBook` (whitespace only)
 * Add existing fields to `publicMemorial`
  - Notes
  - Creator
  * New fields
   - Inscription
   - ErectedBy
   - Dates (container)
    - Erection
    - Creation
    - Opening
   - Provenance
* Let's make the place hierarchy look a bit more user friendly
 - rename `DC Coverage Authority` with `Place`