### PR TITLE
Add quick add permissions to the cataloguer role

### DIFF
--- a/profile/rwahs.xml
+++ b/profile/rwahs.xml
@@ -7488,6 +7488,69 @@
       <actions>
       </actions>
     </role>
+    <role code="cataloguer">
+      <name>Cataloguers</name>
+      <description>Confers actions needed by those editing catalogue entries</description>
+      <actions>
+        <action>can_quicksearch</action>
+        <action>can_set_preferences</action>
+        <action>can_create_adv_search_forms</action>
+        <action>can_edit_adv_search_forms</action>
+        <action>can_delete_adv_search_forms</action>
+        <action>can_use_adv_search_forms</action>
+        <action>can_create_ca_bundle_displays</action>
+        <action>can_edit_ca_bundle_displays</action>
+        <action>can_delete_ca_bundle_displays</action>
+        <action>can_use_ca_bundle_displays</action>
+        <action>can_create_user_groups</action>
+        <action>can_create_sets</action>
+        <action>can_edit_sets</action>
+        <action>can_delete_sets</action>
+        <action>can_view_sets</action>
+        <action>can_quickadd_ca_sets</action>
+        <action>can_create_ca_objects</action>
+        <action>can_edit_ca_objects</action>
+        <action>can_delete_ca_objects</action>
+        <action>can_search_ca_objects</action>
+        <action>can_browse_ca_objects</action>
+        <action>can_create_ca_object_lots</action>
+        <action>can_edit_ca_object_lots</action>
+        <action>can_delete_ca_object_lots</action>
+        <action>can_search_ca_object_lots</action>
+        <action>can_browse_ca_object_lots</action>
+        <action>can_create_ca_entities</action>
+        <action>can_edit_ca_entities</action>
+        <action>can_delete_ca_entities</action>
+        <action>can_search_ca_entities</action>
+        <action>can_browse_ca_entities</action>
+        <action>can_quickadd_ca_entities</action>
+        <action>can_create_ca_places</action>
+        <action>can_edit_ca_places</action>
+        <action>can_delete_ca_places</action>
+        <action>can_search_ca_places</action>
+        <action>can_browse_ca_places</action>
+        <action>can_quickadd_ca_places</action>
+        <action>can_create_ca_occurrences</action>
+        <action>can_edit_ca_occurrences</action>
+        <action>can_delete_ca_occurrences</action>
+        <action>can_search_ca_occurrences</action>
+        <action>can_browse_ca_occurrences</action>
+        <action>can_quickadd_ca_occurrences</action>
+        <action>can_create_ca_collections</action>
+        <action>can_edit_ca_collections</action>
+        <action>can_delete_ca_collections</action>
+        <action>can_search_ca_collections</action>
+        <action>can_browse_ca_collections</action>
+        <action>can_create_ca_storage_locations</action>
+        <action>can_edit_ca_storage_locations</action>
+        <action>can_delete_ca_storage_locations</action>
+        <action>can_search_ca_storage_locations</action>
+        <action>can_browse_ca_storage_locations</action>
+        <action>can_create_ca_lists</action>
+        <action>can_edit_ca_lists</action>
+        <action>can_delete_ca_lists</action>
+      </actions>
+    </role>
   </roles>
   <groups>
     <group code="museum">
@@ -7870,6 +7933,10 @@
     <login user_name="researcher" password="researcher" fname="Researcher" lname="User"
            email="researcher@histwest.org.au">
       <role code="researcher"/>
+    </login>
+    <login user_name="cataloguer" password="cataloguer" fname="Cataloguer" lname="User"
+           email="cataloguer@histwest.org.au">
+      <role code="cataloguer"/>
     </login>
   </logins>
 </profile>

--- a/profile/rwahs.xml
+++ b/profile/rwahs.xml
@@ -7502,7 +7502,6 @@
         <action>can_edit_ca_bundle_displays</action>
         <action>can_delete_ca_bundle_displays</action>
         <action>can_use_ca_bundle_displays</action>
-        <action>can_create_user_groups</action>
         <action>can_create_sets</action>
         <action>can_edit_sets</action>
         <action>can_delete_sets</action>

--- a/tests/Profile/ProfileACLTest.php
+++ b/tests/Profile/ProfileACLTest.php
@@ -57,4 +57,9 @@ class ProfileACLTest extends AbstractProfileTest
             $this->assertEquals(1, $this->xpath->query("/profile/logins/login[@user_name='$role_code']")->length, "An example user for the role `$role_code` should exist");
         }
     }
+
+    public function testCataloguerPermissions()
+    {
+        $this->assertEquals(56, $this->xpath->query('/profile/roles/role[@code="cataloguer"]/actions/action')->length, 'The number of actions in the cataloguer role must be equal.');
+    }
 }

--- a/tests/Profile/ProfileACLTest.php
+++ b/tests/Profile/ProfileACLTest.php
@@ -17,11 +17,12 @@ class ProfileACLTest extends AbstractProfileTest
     public function testProfileContainsRoles()
     {
         $xpath = $this->xpath;
-        $this->assertEquals(4, $xpath->query('/profile/roles/role')->length, 'The number of roles should match');
+        $this->assertEquals(5, $xpath->query('/profile/roles/role')->length, 'The number of roles should match');
         $this->assertEquals(1, $xpath->query('/profile/roles/role[@code="museum"]')->length, 'The role with code "museum" should exist.');
         $this->assertEquals(1, $xpath->query('/profile/roles/role[@code="library"]')->length, 'The role with code "library" should exist.');
         $this->assertEquals(1, $xpath->query('/profile/roles/role[@code="photograph"]')->length, 'The role with code "photograph" should exist.');
         $this->assertEquals(1, $xpath->query('/profile/roles/role[@code="memorial"]')->length, 'The role with code "memorial" should exist.');
+        $this->assertEquals(1, $xpath->query('/profile/roles/role[@code="cataloguer"]')->length, 'The role with code "cataloguer" should exist.');
     }
 
     public function testUIAccess()


### PR DESCRIPTION
 - This overrides cataloguer in `base.xml`.
 - Adds permissions to use the quick add actions for sets, entnties, places and occurrences
 - Still cannot quick add objects, loans