### PR TITLE
XSLT to extract CSV field placements from profile.

### DIFF
--- a/profile/rwahs.xml
+++ b/profile/rwahs.xml
@@ -5018,6 +5018,7 @@
             <placement code="ca_objects_location">
               <bundle>ca_objects_location</bundle>
               <settings>
+                <setting name="label" locale="en_AU">Stored Location</setting>
                 <setting name="locationTrackingMode">ca_movements</setting>
                 <setting name="displayTemplate">
                   <![CDATA[
@@ -5056,9 +5057,15 @@
             </placement>
             <placement code="ca_objects_deaccession">
               <bundle>ca_objects_deaccession</bundle>
+              <settings>
+                <setting name="label" locale="en_AU">Deaccession</setting>
+              </settings>
             </placement>
             <placement code="access">
               <bundle>access</bundle>
+              <settings>
+                <setting name="label" locale="en_AU">Access Control</setting>
+              </settings>
             </placement>
             <placement code="ca_attribute_AcquisitionNotes">
               <bundle>ca_attribute_AcquisitionNotes</bundle>
@@ -5208,6 +5215,9 @@
             </placement>
             <placement code="ca_object_representations">
               <bundle>ca_object_representations</bundle>
+              <settings>
+                <setting name="label" locale="en_AU">Media</setting>
+              </settings>
             </placement>
           </bundlePlacements>
         </screen>
@@ -5220,6 +5230,9 @@
           <bundlePlacements>
             <placement code="idno">
               <bundle>idno</bundle>
+              <settings>
+                <setting name="label" locale="en_AU">Accession number</setting>
+              </settings>
             </placement>
             <placement code="ca_attribute_ConditionReportContainer">
               <bundle>ca_attribute_ConditionReportContainer</bundle>
@@ -5411,6 +5424,9 @@
             </placement>
             <placement code="ca_object_representations">
               <bundle>ca_object_representations</bundle>
+              <settings>
+                <setting name="label" locale="en_AU">Media</setting>
+              </settings>
             </placement>
             <placement code="ca_attribute_Purchased">
               <bundle>ca_attribute_Purchased</bundle>
@@ -5525,9 +5541,15 @@
             </placement>
             <placement code="ca_objects_deaccession">
               <bundle>ca_objects_deaccession</bundle>
+              <settings>
+                <setting name="label" locale="en_AU">Deaccession</setting>
+              </settings>
             </placement>
             <placement code="access">
               <bundle>access</bundle>
+              <settings>
+                <setting name="label" locale="en_AU">Access Control</setting>
+              </settings>
             </placement>
           </bundlePlacements>
         </screen>
@@ -5772,12 +5794,21 @@
             </placement>
             <placement code="ca_objects_deaccession">
               <bundle>ca_objects_deaccession</bundle>
+              <settings>
+                <setting name="label" locale="en_AU">Deaccession</setting>
+              </settings>
             </placement>
             <placement code="ca_object_representations">
               <bundle>ca_object_representations</bundle>
+              <settings>
+                <setting name="label" locale="en_AU">Media</setting>
+              </settings>
             </placement>
             <placement code="access">
               <bundle>access</bundle>
+              <settings>
+                <setting name="label" locale="en_AU">Access Control</setting>
+              </settings>
             </placement>
           </bundlePlacements>
         </screen>
@@ -5910,6 +5941,9 @@
             </placement>
             <placement code="ca_object_representations">
               <bundle>ca_object_representations</bundle>
+              <settings>
+                <setting name="label" locale="en_AU">Media</setting>
+              </settings>
             </placement>
           </bundlePlacements>
         </screen>
@@ -6121,7 +6155,7 @@
             <placement code="ca_object_representations">
               <bundle>ca_object_representations</bundle>
               <settings>
-                <setting name="label" locale="en_AU">Conservation Images</setting>
+                <setting name="label" locale="en_AU">Conservation Media</setting>
               </settings>
             </placement>
           </bundlePlacements>
@@ -6243,6 +6277,9 @@
             </placement>
             <placement code="access">
               <bundle>access</bundle>
+              <settings>
+                <setting name="label" locale="en_AU">Access Control</setting>
+              </settings>
             </placement>
             <placement code="status">
               <bundle>status</bundle>
@@ -6329,6 +6366,9 @@
             </placement>
             <placement code="access">
               <bundle>access</bundle>
+              <settings>
+                <setting name="label" locale="en_AU">Access Control</setting>
+              </settings>
             </placement>
             <placement code="status">
               <bundle>status</bundle>
@@ -6518,6 +6558,9 @@
             </placement>
             <placement code="access">
               <bundle>access</bundle>
+              <settings>
+                <setting name="label" locale="en_AU">Access Control</setting>
+              </settings>
             </placement>
             <placement code="status">
               <bundle>status</bundle>
@@ -6598,6 +6641,9 @@
             </placement>
             <placement code="access">
               <bundle>access</bundle>
+              <settings>
+                <setting name="label" locale="en_AU">Access Control</setting>
+              </settings>
             </placement>
             <placement code="status">
               <bundle>status</bundle>
@@ -6684,6 +6730,9 @@
             </placement>
             <placement code="access">
               <bundle>access</bundle>
+              <settings>
+                <setting name="label" locale="en_AU">Access Control</setting>
+              </settings>
             </placement>
             <placement code="status">
               <bundle>status</bundle>
@@ -7662,6 +7711,9 @@
         </placement>
         <placement code="access">
           <bundle>ca_objects.access</bundle>
+          <settings>
+            <setting name="label" locale="en_AU">Access Control</setting>
+          </settings>
         </placement>
         <placement code="status">
           <bundle>ca_objects.status</bundle>
@@ -7695,6 +7747,9 @@
         </placement>
         <placement code="access">
           <bundle>ca_entities.access</bundle>
+          <settings>
+            <setting name="label" locale="en_AU">Access Control</setting>
+          </settings>
         </placement>
         <placement code="status">
           <bundle>ca_entities.status</bundle>
@@ -7722,6 +7777,9 @@
         </placement>
         <placement code="access">
           <bundle>ca_places.access</bundle>
+          <settings>
+            <setting name="label" locale="en_AU">Access Control</setting>
+          </settings>
         </placement>
         <placement code="status">
           <bundle>ca_places.status</bundle>
@@ -7749,6 +7807,9 @@
         </placement>
         <placement code="access">
           <bundle>ca_places.access</bundle>
+          <settings>
+            <setting name="label" locale="en_AU">Access Control</setting>
+          </settings>
         </placement>
         <placement code="status">
           <bundle>ca_places.status</bundle>
@@ -7776,6 +7837,9 @@
         </placement>
         <placement code="access">
           <bundle>ca_collections.access</bundle>
+          <settings>
+            <setting name="label" locale="en_AU">Access Control</setting>
+          </settings>
         </placement>
         <placement code="status">
           <bundle>ca_collections.status</bundle>

--- a/transforms/extract-placements-csv.xslt
+++ b/transforms/extract-placements-csv.xslt
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+    <!-- Don't output the XML specifier or apply any XML/HTML formatting. -->
+    <xsl:output method="text" media-type="text/csv" />
+
+    <!-- Identity template strips everything by default. -->
+    <xsl:template match="node()|@*">
+        <xsl:apply-templates select="node()|@*"/>
+    </xsl:template>
+
+    <!-- Produce headers on the lowest common ancestor.  &#xa; produces a newline. -->
+    <xsl:template match="/profile/userInterfaces">
+        <xsl:text>"User Interface Name","Screen Name","Field Name","Bundle Code","Help Text"&#xa;</xsl:text>
+        <xsl:apply-templates select="node()|@*"/>
+    </xsl:template>
+
+    <!-- Produce a single record per <placement> in the source; look up the tree to find parent screen and UI names -->
+    <!-- Note this matches object UIs only; remove the @type check to produce all UIs for all data types. -->
+    <xsl:template match="/profile/userInterfaces/userInterface[@type='ca_objects']/screens/screen/bundlePlacements/placement">
+        <xsl:text>"</xsl:text>
+        <xsl:value-of select="../../../../labels/label[@locale='en_AU']/name/text()" />
+        <xsl:text>",</xsl:text>
+        <xsl:text>"</xsl:text>
+        <xsl:value-of select="../../labels/label[@locale='en_AU']/name/text()" />
+        <xsl:text>",</xsl:text>
+        <xsl:text>"</xsl:text>
+        <xsl:value-of select="settings/setting[@name='label'][@locale='en_AU']/text()" />
+        <xsl:text>",</xsl:text>
+        <xsl:value-of select="@code" />
+        <xsl:text>",""&#xa;</xsl:text>
+    </xsl:template>
+</xsl:stylesheet>

--- a/transforms/extract-placements-csv.xslt
+++ b/transforms/extract-placements-csv.xslt
@@ -17,16 +17,21 @@
     <!-- Produce a single record per <placement> in the source; look up the tree to find parent screen and UI names -->
     <!-- Note this matches object UIs only; remove the @type check to produce all UIs for all data types. -->
     <xsl:template match="/profile/userInterfaces/userInterface[@type='ca_objects']/screens/screen/bundlePlacements/placement">
+        <xsl:variable name="placementLabel" select="settings/setting[@name='label'][@locale='en_AU']/text()" />
+        <xsl:variable name="elementCode" select="substring-after(./bundle/text(), 'ca_attribute_')" />
         <xsl:text>"</xsl:text>
         <xsl:value-of select="../../../../labels/label[@locale='en_AU']/name/text()" />
-        <xsl:text>",</xsl:text>
-        <xsl:text>"</xsl:text>
+        <xsl:text>","</xsl:text>
         <xsl:value-of select="../../labels/label[@locale='en_AU']/name/text()" />
-        <xsl:text>",</xsl:text>
-        <xsl:text>"</xsl:text>
-        <xsl:value-of select="settings/setting[@name='label'][@locale='en_AU']/text()" />
-        <xsl:text>",</xsl:text>
-        <xsl:value-of select="@code" />
+        <xsl:text>","</xsl:text>
+        <xsl:if test="$placementLabel">
+            <xsl:value-of select="$placementLabel" />
+        </xsl:if>
+        <xsl:if test="not($placementLabel)">
+            <xsl:value-of select="/profile/elementSets/metadataElement[@code=$elementCode]/labels/label[@locale='en_AU']/name/text()" />
+        </xsl:if>
+        <xsl:text>","</xsl:text>
+        <xsl:value-of select="bundle/text()" />
         <xsl:text>",""&#xa;</xsl:text>
     </xsl:template>
 </xsl:stylesheet>

--- a/transforms/extract-placements-csv.xslt
+++ b/transforms/extract-placements-csv.xslt
@@ -17,21 +17,31 @@
     <!-- Produce a single record per <placement> in the source; look up the tree to find parent screen and UI names -->
     <!-- Note this matches object UIs only; remove the @type check to produce all UIs for all data types. -->
     <xsl:template match="/profile/userInterfaces/userInterface[@type='ca_objects']/screens/screen/bundlePlacements/placement">
-        <xsl:variable name="placementLabel" select="settings/setting[@name='label'][@locale='en_AU']/text()" />
+        <xsl:variable name="placementLabel" select="normalize-space(settings/setting[@name='label'][@locale='en_AU']/text())" />
+        <xsl:variable name="placementDescription" select="normalize-space(settings/setting[@name='description'][@locale='en_AU']/text())" />
         <xsl:variable name="elementCode" select="substring-after(./bundle/text(), 'ca_attribute_')" />
+        <xsl:variable name="elementLabel" select="normalize-space(/profile/elementSets/metadataElement[@code=$elementCode]/labels/label[@locale='en_AU']/name/text())" />
+        <xsl:variable name="elementDescription" select="normalize-space(/profile/elementSets/metadataElement[@code=$elementCode]/labels/label[@locale='en_AU']/description/text())" />
         <xsl:text>"</xsl:text>
-        <xsl:value-of select="../../../../labels/label[@locale='en_AU']/name/text()" />
+        <xsl:value-of select="normalize-space(../../../../labels/label[@locale='en_AU']/name/text())" />
         <xsl:text>","</xsl:text>
-        <xsl:value-of select="../../labels/label[@locale='en_AU']/name/text()" />
+        <xsl:value-of select="normalize-space(../../labels/label[@locale='en_AU']/name/text())" />
         <xsl:text>","</xsl:text>
         <xsl:if test="$placementLabel">
             <xsl:value-of select="$placementLabel" />
         </xsl:if>
         <xsl:if test="not($placementLabel)">
-            <xsl:value-of select="/profile/elementSets/metadataElement[@code=$elementCode]/labels/label[@locale='en_AU']/name/text()" />
+            <xsl:value-of select="$elementLabel" />
         </xsl:if>
         <xsl:text>","</xsl:text>
         <xsl:value-of select="bundle/text()" />
-        <xsl:text>",""&#xa;</xsl:text>
+        <xsl:text>","</xsl:text>
+        <xsl:if test="$placementDescription">
+            <xsl:value-of select="$placementDescription" />
+        </xsl:if>
+        <xsl:if test="not($placementDescription)">
+            <xsl:value-of select="$elementDescription" />
+        </xsl:if>
+        <xsl:text>"&#xa;</xsl:text>
     </xsl:template>
 </xsl:stylesheet>


### PR DESCRIPTION
For RWAHS-111 "List of fields per screen to fill in help text"

+ Extracts all placements, by screen, by UI, into a CSV format.
+Outputs 5 columns with headers: "User Interface Name","Screen Name","Field Name","Bundle Code","Help Text"
+ "Help Text" is an empty column for client to populate and send back.
+ Can be manually executed in PhpStorm.
