### PR TITLE
Fix subject import and relationship types

### DIFF
--- a/profile/rwahs.xml
+++ b/profile/rwahs.xml
@@ -6023,7 +6023,7 @@
             <placement code="idno">
               <bundle>idno</bundle>
               <settings>
-                <setting name="label" locale="en_AU">Subject Name</setting>
+                <setting name="label" locale="en_AU">Subject Identifier</setting>
               </settings>
             </placement>
             <placement code="preferred_labels">
@@ -8984,7 +8984,7 @@
         <placement code="idno">
           <bundle>ca_occurrences.idno</bundle>
           <settings>
-            <setting name="label" locale="en_AU">Subject Name</setting>
+            <setting name="label" locale="en_AU">Subject Identifier</setting>
           </settings>
         </placement>
         <placement code="preferred_labels">

--- a/profile/rwahs.xml
+++ b/profile/rwahs.xml
@@ -304,55 +304,13 @@
         </label>
       </labels>
       <items>
-        <item idno="subject" enabled="1" default="0">
+        <item idno="Subject" enabled="1" default="0">
           <labels>
             <label locale="en_AU" preferred="1">
-              <name_singular>Subject List Entry</name_singular>
-              <name_plural>Subject List Entries</name_plural>
+              <name_singular>Subject</name_singular>
+              <name_plural>Subjects</name_plural>
             </label>
           </labels>
-          <items>
-            <item idno="Person" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>Person</name_singular>
-                  <name_plural>People</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="Organization" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>Organization</name_singular>
-                  <name_plural>Organizations</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="Topic" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>Topic</name_singular>
-                  <name_plural>Topics</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="Place" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>Place</name_singular>
-                  <name_plural>Places</name_plural>
-                </label>
-              </labels>
-            </item>
-            <item idno="Event" enabled="1" default="0">
-              <labels>
-                <label locale="en_AU" preferred="1">
-                  <name_singular>Event</name_singular>
-                  <name_plural>Events</name_plural>
-                </label>
-              </labels>
-            </item>
-          </items>
         </item>
         <item idno="Conservation" enabled="1" default="0">
           <labels>
@@ -1133,9 +1091,9 @@
             <setting name="minimumAttributeBundlesToDisplay">1</setting>
           </settings>
         </restriction>
-        <restriction code="subject">
+        <restriction code="Subject">
           <table>ca_occurrences</table>
-          <type>subject</type>
+          <type>Subject</type>
           <includeSubtypes>true</includeSubtypes>
           <settings>
             <setting name="minAttributesPerRow">0</setting>
@@ -1178,7 +1136,7 @@
         </restriction>
         <restriction code="occurrences">
           <table>ca_occurrences</table>
-          <type>subject</type>
+          <type>Subject</type>
           <includeSubtypes>true</includeSubtypes>
           <settings>
             <setting name="minAttributesPerRow">0</setting>
@@ -1613,7 +1571,7 @@
         </restriction>
         <restriction code="r3">
           <table>ca_occurrences</table>
-          <type>subject</type>
+          <type>Subject</type>
           <includeSubtypes>true</includeSubtypes>
           <settings>
             <setting name="minAttributesPerRow">0</setting>
@@ -4636,7 +4594,7 @@
       <typeRestrictions>
         <restriction code="museum_SubjectDates">
           <table>ca_occurrences</table>
-          <type>subject</type>
+          <type>Subject</type>
           <includeSubtypes>true</includeSubtypes>
           <settings>
             <setting name="minAttributesPerRow">0</setting>
@@ -4671,7 +4629,8 @@
       <typeRestrictions>
         <restriction code="interstitial_object_Association">
           <table>ca_objects_x_occurrences</table>
-          <type>describes</type>
+          <!-- This is the code of the relationship type, not the occurrence type-->
+          <type>subject</type>
           <settings>
             <setting name="minAttributesPerRow">0</setting>
             <setting name="maxAttributesPerRow">1</setting>
@@ -4680,6 +4639,8 @@
         </restriction>
         <restriction code="interstitial_occurrence_Association">
           <table>ca_occurrences_x_occurrences</table>
+          <!-- This is the code of the relationship type, not the occurrence type-->
+          <type>subject</type>
           <settings>
             <setting name="minAttributesPerRow">0</setting>
             <setting name="maxAttributesPerRow">1</setting>
@@ -5128,11 +5089,7 @@
                 <setting name="restrict_to_relationship_types">depicts</setting>
                 <setting name="restrict_to_relationship_types">used</setting>
                 <setting name="restrict_to_relationship_types">describes</setting>
-                <setting name="restrict_to_types">Event</setting>
-                <setting name="restrict_to_types">Organization</setting>
-                <setting name="restrict_to_types">Person</setting>
-                <setting name="restrict_to_types">Place</setting>
-                <setting name="restrict_to_types">Topic</setting>
+                <setting name="restrict_to_types">Subject</setting>
                 <setting name="dont_include_subtypes_in_type_restriction">0</setting>
                 <setting name="list_format">list</setting>
                 <setting name="sortDirection">ASC</setting>
@@ -5364,7 +5321,7 @@
             <placement code="ca_attribute_Series">
               <bundle>ca_attribute_Series</bundle>
             </placement>
-            <placement code="subject">
+            <placement code="Subject">
               <bundle>ca_occurrences</bundle>
               <settings>
                 <setting name="label" locale="en_AU">Subject headings</setting>
@@ -5374,12 +5331,7 @@
                 <setting name="restrict_to_relationship_types">depicts</setting>
                 <setting name="restrict_to_relationship_types">used</setting>
                 <setting name="restrict_to_relationship_types">describes</setting>
-                <setting name="restrict_to_types">Event</setting>
-                <setting name="restrict_to_types">Organization</setting>
-                <setting name="restrict_to_types">Person</setting>
-                <setting name="restrict_to_types">Place</setting>
-                <setting name="restrict_to_types">Topic</setting>
-                <setting name="restrict_to_types">subject</setting>
+                <setting name="restrict_to_types">Subject</setting>
                 <setting name="dont_include_subtypes_in_type_restriction">0</setting>
                 <setting name="list_format">list</setting>
                 <setting name="sortDirection">ASC</setting>
@@ -5397,8 +5349,6 @@
                       <dt>Subject Dates:</dt>
                       <dd>^ca_occurrences.SubjectDates</dd>
                     </ifdef>
-                    <dt>Type:</dt>
-                    <dd>^ca_occurrences.type_id</dd>
                     <ifdef code="ca_occurrences.Description">
                       <dt>Description:</dt>
                       <dd>^ca_occurrences.Description</dd>
@@ -5625,7 +5575,7 @@
             <placement code="ca_attribute_PhysicalDescription">
               <bundle>ca_attribute_PhysicalDescription</bundle>
             </placement>
-            <placement code="subject">
+            <placement code="Subject">
               <bundle>ca_occurrences</bundle>
               <settings>
                 <setting name="label" locale="en_AU">Subject authority list</setting>
@@ -5635,12 +5585,7 @@
                 <setting name="restrict_to_relationship_types">depicts</setting>
                 <setting name="restrict_to_relationship_types">used</setting>
                 <setting name="restrict_to_relationship_types">describes</setting>
-                <setting name="restrict_to_types">Event</setting>
-                <setting name="restrict_to_types">Organization</setting>
-                <setting name="restrict_to_types">Person</setting>
-                <setting name="restrict_to_types">Place</setting>
-                <setting name="restrict_to_types">Topic</setting>
-                <setting name="restrict_to_types">subject</setting>
+                <setting name="restrict_to_types">Subject</setting>
                 <setting name="dont_include_subtypes_in_type_restriction">0</setting>
                 <setting name="list_format">list</setting>
                 <setting name="sortDirection">ASC</setting>
@@ -5879,7 +5824,7 @@
             <placement code="ca_attribute_Dates">
               <bundle>ca_attribute_Dates</bundle>
             </placement>
-            <placement code="subject">
+            <placement code="Subject">
               <bundle>ca_occurrences</bundle>
               <settings>
                 <setting name="label" locale="en_AU">Subject headings</setting>
@@ -5889,11 +5834,7 @@
                 <setting name="restrict_to_relationship_types">depicts</setting>
                 <setting name="restrict_to_relationship_types">used</setting>
                 <setting name="restrict_to_relationship_types">describes</setting>
-                <setting name="restrict_to_types">Event</setting>
-                <setting name="restrict_to_types">Organization</setting>
-                <setting name="restrict_to_types">Person</setting>
-                <setting name="restrict_to_types">Place</setting>
-                <setting name="restrict_to_types">Topic</setting>
+                <setting name="restrict_to_types">Subject</setting>
                 <setting name="dont_include_subtypes_in_type_restriction">0</setting>
                 <setting name="list_format">list</setting>
                 <setting name="sortDirection">ASC</setting>
@@ -6042,13 +5983,6 @@
             <placement code="ca_entities">
               <bundle>ca_entities</bundle>
             </placement>
-            <placement code="ca_events">
-              <bundle>ca_occurrences</bundle>
-              <settings>
-                <setting name="restrict_to_type">Event</setting>
-                <setting name="label" locale="en_AU">Related events</setting>
-              </settings>
-            </placement>
             <placement code="ca_places">
               <bundle>ca_places</bundle>
             </placement>
@@ -6069,7 +6003,7 @@
         </label>
       </labels>
       <typeRestrictions>
-        <restriction type="subject"/>
+        <restriction type="Subject"/>
       </typeRestrictions>
       <groupAccess>
         <permission group="admin" access="edit"/>
@@ -6415,13 +6349,6 @@
             </placement>
             <placement code="ca_entities">
               <bundle>ca_entities</bundle>
-            </placement>
-            <placement code="ca_events">
-              <bundle>ca_occurrences</bundle>
-              <settings>
-                <setting name="restrict_to_type">Event</setting>
-                <setting name="label" locale="en_AU">Related events</setting>
-              </settings>
             </placement>
             <placement code="ca_places">
               <bundle>ca_places</bundle>
@@ -6931,7 +6858,7 @@
             </label>
           </labels>
           <subTypeLeft/>
-          <subTypeRight>Event</subTypeRight>
+          <subTypeRight>Subject</subTypeRight>
         </type>
         <type code="used" default="0">
           <labels>
@@ -6941,7 +6868,17 @@
             </label>
           </labels>
           <subTypeLeft/>
-          <subTypeRight>Event</subTypeRight>
+          <subTypeRight>Subject</subTypeRight>
+        </type>
+        <type code="subject" default="0">
+          <labels>
+            <label locale="en_AU">
+              <typename>has subject</typename>
+              <typename_reverse>is subject of</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft/>
+          <subTypeRight>Subject</subTypeRight>
         </type>
         <type code="describes" default="0">
           <labels>
@@ -7034,6 +6971,16 @@
           </labels>
           <subTypeLeft/>
           <subTypeRight/>
+        </type>
+        <type code="subject" default="1">
+          <labels>
+            <label locale="en_AU">
+              <typename>has related subject</typename>
+              <typename_reverse>has related subject</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft>Subject</subTypeLeft>
+          <subTypeRight>Subject</subTypeRight>
         </type>
       </types>
     </relationshipTable>
@@ -7211,7 +7158,7 @@
             </label>
           </labels>
           <subTypeLeft/>
-          <subTypeRight>Event</subTypeRight>
+          <subTypeRight>Subject</subTypeRight>
         </type>
       </types>
     </relationshipTable>
@@ -7351,7 +7298,7 @@
             </label>
           </labels>
           <subTypeLeft/>
-          <subTypeRight>Event</subTypeRight>
+          <subTypeRight>Subject</subTypeRight>
         </type>
       </types>
     </relationshipTable>
@@ -7493,7 +7440,7 @@
             </label>
           </labels>
           <subTypeLeft/>
-          <subTypeRight>Event</subTypeRight>
+          <subTypeRight>Subject</subTypeRight>
         </type>
         <type code="describes" default="1">
           <labels>
@@ -7503,7 +7450,7 @@
             </label>
           </labels>
           <subTypeLeft/>
-          <subTypeRight>Event</subTypeRight>
+          <subTypeRight>Subject</subTypeRight>
         </type>
       </types>
     </relationshipTable>
@@ -7829,12 +7776,7 @@
             <setting name="restrict_to_relationship_types">depicts</setting>
             <setting name="restrict_to_relationship_types">used</setting>
             <setting name="restrict_to_relationship_types">describes</setting>
-            <setting name="restrict_to_types">Event</setting>
-            <setting name="restrict_to_types">Organization</setting>
-            <setting name="restrict_to_types">Person</setting>
-            <setting name="restrict_to_types">Place</setting>
-            <setting name="restrict_to_types">Topic</setting>
-            <setting name="restrict_to_types">subject</setting>
+            <setting name="restrict_to_types">Subject</setting>
             <setting name="dont_include_subtypes_in_type_restriction">0</setting>
             <setting name="list_format">list</setting>
             <setting name="sortDirection">ASC</setting>
@@ -8137,11 +8079,7 @@
             <setting name="restrict_to_relationship_types">depicts</setting>
             <setting name="restrict_to_relationship_types">used</setting>
             <setting name="restrict_to_relationship_types">describes</setting>
-            <setting name="restrict_to_types">Event</setting>
-            <setting name="restrict_to_types">Organization</setting>
-            <setting name="restrict_to_types">Person</setting>
-            <setting name="restrict_to_types">Place</setting>
-            <setting name="restrict_to_types">Topic</setting>
+            <setting name="restrict_to_types">Subject</setting>
             <setting name="dont_include_subtypes_in_type_restriction">0</setting>
             <setting name="list_format">list</setting>
             <setting name="sortDirection">ASC</setting>
@@ -8485,11 +8423,7 @@
             <setting name="restrict_to_relationship_types">depicts</setting>
             <setting name="restrict_to_relationship_types">used</setting>
             <setting name="restrict_to_relationship_types">describes</setting>
-            <setting name="restrict_to_types">Event</setting>
-            <setting name="restrict_to_types">Organization</setting>
-            <setting name="restrict_to_types">Person</setting>
-            <setting name="restrict_to_types">Place</setting>
-            <setting name="restrict_to_types">Topic</setting>
+            <setting name="restrict_to_types">Subject</setting>
             <setting name="dont_include_subtypes_in_type_restriction">0</setting>
             <setting name="list_format">list</setting>
             <setting name="sortDirection">ASC</setting>
@@ -8768,12 +8702,7 @@
             <setting name="restrict_to_relationship_types">depicts</setting>
             <setting name="restrict_to_relationship_types">used</setting>
             <setting name="restrict_to_relationship_types">describes</setting>
-            <setting name="restrict_to_types">Event</setting>
-            <setting name="restrict_to_types">Organization</setting>
-            <setting name="restrict_to_types">Person</setting>
-            <setting name="restrict_to_types">Place</setting>
-            <setting name="restrict_to_types">Topic</setting>
-            <setting name="restrict_to_types">subject</setting>
+            <setting name="restrict_to_types">Subject</setting>
             <setting name="dont_include_subtypes_in_type_restriction">0</setting>
             <setting name="list_format">list</setting>
             <setting name="sortDirection">ASC</setting>

--- a/profile/rwahs.xml
+++ b/profile/rwahs.xml
@@ -5335,9 +5335,6 @@
                 <setting name="readonly"/>
                 <setting name="expand_collapse_value">dont_force</setting>
                 <setting name="expand_collapse_no_value">dont_force</setting>
-                <setting name="restrict_to_relationship_types">depicts</setting>
-                <setting name="restrict_to_relationship_types">used</setting>
-                <setting name="restrict_to_relationship_types">describes</setting>
                 <setting name="restrict_to_relationship_types">subject</setting>
                 <setting name="restrict_to_types">Subject</setting>
                 <setting name="dont_include_subtypes_in_type_restriction">0</setting>
@@ -7889,9 +7886,6 @@
             <setting name="readonly"/>
             <setting name="expand_collapse_value">dont_force</setting>
             <setting name="expand_collapse_no_value">dont_force</setting>
-            <setting name="restrict_to_relationship_types">depicts</setting>
-            <setting name="restrict_to_relationship_types">used</setting>
-            <setting name="restrict_to_relationship_types">describes</setting>
             <setting name="restrict_to_relationship_types">subject</setting>
             <setting name="restrict_to_types">Subject</setting>
             <setting name="dont_include_subtypes_in_type_restriction">0</setting>
@@ -7925,7 +7919,7 @@
                     </ifdef>
                   </dl>
 
-                ]]></setting>
+                  ]]></setting>
             <setting name="minRelationshipsPerRow"/>
             <setting name="maxRelationshipsPerRow">255</setting>
             <setting name="showCurrentOnly">0</setting>
@@ -8169,7 +8163,7 @@
                     </ifdef>
                   </dl>
 
-                ]]></setting>
+                  ]]></setting>
             <setting name="minRelationshipsPerRow"/>
             <setting name="maxRelationshipsPerRow">255</setting>
             <setting name="showCurrentOnly">0</setting>
@@ -8357,7 +8351,7 @@
                     </unit>
                   </unit>
 
-                ]]></setting>
+                  ]]></setting>
           </settings>
         </placement>
         <placement code="ca_objects_location">
@@ -8512,7 +8506,7 @@
                     </ifdef>
                   </dl>
 
-                ]]></setting>
+                  ]]></setting>
             <setting name="minRelationshipsPerRow"/>
             <setting name="maxRelationshipsPerRow">255</setting>
             <setting name="showCurrentOnly">0</setting>
@@ -8624,7 +8618,7 @@
                       <l>^ca_object_representations.media.medium</l>
                   </unit>
 
-                ]]></setting>
+                  ]]></setting>
           </settings>
         </placement>
         <placement code="ca_attribute_PhysicalCondition">
@@ -8738,7 +8732,7 @@
                     </ifdef>
                   </dl>
 
-                ]]></setting>
+                  ]]></setting>
             <setting name="minRelationshipsPerRow"/>
             <setting name="maxRelationshipsPerRow">255</setting>
             <setting name="showCurrentOnly">0</setting>
@@ -9222,7 +9216,7 @@
                     </unit>
                   </unit>
 
-                ]]></setting>
+                  ]]></setting>
             <setting name="minRelationshipsPerRow">1</setting>
             <setting name="maxRelationshipsPerRow">1</setting>
             <setting name="showCurrentOnly">1</setting>

--- a/profile/rwahs.xml
+++ b/profile/rwahs.xml
@@ -4981,7 +4981,7 @@
                     </unit>
                   </unit>
 
-                ]]></setting>
+                  ]]></setting>
               </settings>
             </placement>
             <placement code="ca_objects_location">
@@ -5130,7 +5130,7 @@
                     </ifdef>
                   </dl>
 
-                ]]></setting>
+                  ]]></setting>
                 <setting name="minRelationshipsPerRow"/>
                 <setting name="maxRelationshipsPerRow">255</setting>
                 <setting name="showCurrentOnly">0</setting>
@@ -5242,7 +5242,7 @@
                       <l>^ca_object_representations.media.medium</l>
                   </unit>
 
-                ]]></setting>
+                  ]]></setting>
               </settings>
             </placement>
             <placement code="ca_attribute_PhysicalCondition">
@@ -5371,7 +5371,7 @@
                     </ifdef>
                   </dl>
 
-                ]]></setting>
+                  ]]></setting>
                 <setting name="minRelationshipsPerRow"/>
                 <setting name="maxRelationshipsPerRow">255</setting>
                 <setting name="showCurrentOnly">0</setting>
@@ -5626,7 +5626,7 @@
                     </ifdef>
                   </dl>
 
-                ]]></setting>
+                  ]]></setting>
                 <setting name="minRelationshipsPerRow"/>
                 <setting name="maxRelationshipsPerRow">255</setting>
                 <setting name="showCurrentOnly">0</setting>
@@ -5874,7 +5874,7 @@
                     </ifdef>
                   </dl>
 
-                ]]></setting>
+                  ]]></setting>
                 <setting name="minRelationshipsPerRow"/>
                 <setting name="maxRelationshipsPerRow">255</setting>
                 <setting name="showCurrentOnly">0</setting>
@@ -6765,7 +6765,7 @@
                     </unit>
                   </unit>
 
-                ]]></setting>
+                  ]]></setting>
                 <setting name="minRelationshipsPerRow">1</setting>
                 <setting name="maxRelationshipsPerRow">1</setting>
                 <setting name="showCurrentOnly">1</setting>
@@ -7882,7 +7882,7 @@
           <bundle>ca_objects.Series</bundle>
           <settings/>
         </placement>
-        <placement code="subject">
+        <placement code="Subject">
           <bundle>ca_occurrences</bundle>
           <settings>
             <setting name="label" locale="en_AU">Subject headings</setting>
@@ -8126,7 +8126,7 @@
           <bundle>ca_objects.Dates</bundle>
           <settings/>
         </placement>
-        <placement code="subject">
+        <placement code="Subject">
           <bundle>ca_occurrences</bundle>
           <settings>
             <setting name="label" locale="en_AU">Subject headings</setting>
@@ -8695,7 +8695,7 @@
           <bundle>ca_objects.PhysicalDescription</bundle>
           <settings/>
         </placement>
-        <placement code="subject">
+        <placement code="Subject">
           <bundle>ca_occurrences</bundle>
           <settings>
             <setting name="label" locale="en_AU">Subject authority list</setting>
@@ -8965,13 +8965,6 @@
         <placement code="ca_entities">
           <bundle>ca_entities</bundle>
           <settings/>
-        </placement>
-        <placement code="ca_events">
-          <bundle>ca_occurrences</bundle>
-          <settings>
-            <setting name="restrict_to_type">Event</setting>
-            <setting name="label" locale="en_AU">Related events</setting>
-          </settings>
         </placement>
         <placement code="ca_places">
           <bundle>ca_places</bundle>

--- a/profile/rwahs.xml
+++ b/profile/rwahs.xml
@@ -4626,6 +4626,14 @@
           <name>Association</name>
         </label>
       </labels>
+      <settings>
+        <setting name="usewysiwygeditor">0</setting>
+        <setting name="fieldWidth">115</setting>
+        <setting name="fieldHeight">3</setting>
+        <setting name="suggestExistingValues">1</setting>
+        <setting name="minChars">0</setting>
+        <setting name="maxChars">255</setting>
+      </settings>
       <typeRestrictions>
         <restriction code="interstitial_object_Association">
           <table>ca_objects_x_occurrences</table>
@@ -5089,6 +5097,7 @@
                 <setting name="restrict_to_relationship_types">depicts</setting>
                 <setting name="restrict_to_relationship_types">used</setting>
                 <setting name="restrict_to_relationship_types">describes</setting>
+                <setting name="restrict_to_relationship_types">subject</setting>
                 <setting name="restrict_to_types">Subject</setting>
                 <setting name="dont_include_subtypes_in_type_restriction">0</setting>
                 <setting name="list_format">list</setting>
@@ -5107,8 +5116,6 @@
                       <dt>Subject Dates:</dt>
                       <dd>^ca_occurrences.SubjectDates</dd>
                     </ifdef>
-                    <dt>Type:</dt>
-                    <dd>^ca_occurrences.type_id</dd>
                     <ifdef code="ca_occurrences.Description">
                       <dt>Description:</dt>
                       <dd>^ca_occurrences.Description</dd>
@@ -5118,7 +5125,7 @@
                       <dd>^ca_objects_x_occurrences.Association</dd>
                     </ifdef>
                     <ifdef code="ca_objects_x_occurrences.SubjectDates">
-                      <dt>Dates:</dt>
+                      <dt>Relationship Dates:</dt>
                       <dd>^ca_objects_x_occurrences.SubjectDates</dd>
                     </ifdef>
                   </dl>
@@ -5331,6 +5338,7 @@
                 <setting name="restrict_to_relationship_types">depicts</setting>
                 <setting name="restrict_to_relationship_types">used</setting>
                 <setting name="restrict_to_relationship_types">describes</setting>
+                <setting name="restrict_to_relationship_types">subject</setting>
                 <setting name="restrict_to_types">Subject</setting>
                 <setting name="dont_include_subtypes_in_type_restriction">0</setting>
                 <setting name="list_format">list</setting>
@@ -5358,7 +5366,7 @@
                       <dd>^ca_objects_x_occurrences.Association</dd>
                     </ifdef>
                     <ifdef code="ca_objects_x_occurrences.SubjectDates">
-                      <dt>Dates:</dt>
+                      <dt>Relationship Dates:</dt>
                       <dd>^ca_objects_x_occurrences.SubjectDates</dd>
                     </ifdef>
                   </dl>
@@ -5585,6 +5593,7 @@
                 <setting name="restrict_to_relationship_types">depicts</setting>
                 <setting name="restrict_to_relationship_types">used</setting>
                 <setting name="restrict_to_relationship_types">describes</setting>
+                <setting name="restrict_to_relationship_types">subject</setting>
                 <setting name="restrict_to_types">Subject</setting>
                 <setting name="dont_include_subtypes_in_type_restriction">0</setting>
                 <setting name="list_format">list</setting>
@@ -5603,8 +5612,6 @@
                       <dt>Subject Dates:</dt>
                       <dd>^ca_occurrences.SubjectDates</dd>
                     </ifdef>
-                    <dt>Type:</dt>
-                    <dd>^ca_occurrences.type_id</dd>
                     <ifdef code="ca_occurrences.Description">
                       <dt>Description:</dt>
                       <dd>^ca_occurrences.Description</dd>
@@ -5614,7 +5621,7 @@
                       <dd>^ca_objects_x_occurrences.Association</dd>
                     </ifdef>
                     <ifdef code="ca_objects_x_occurrences.SubjectDates">
-                      <dt>Dates:</dt>
+                      <dt>Relationship Dates:</dt>
                       <dd>^ca_objects_x_occurrences.SubjectDates</dd>
                     </ifdef>
                   </dl>
@@ -5834,6 +5841,7 @@
                 <setting name="restrict_to_relationship_types">depicts</setting>
                 <setting name="restrict_to_relationship_types">used</setting>
                 <setting name="restrict_to_relationship_types">describes</setting>
+                <setting name="restrict_to_relationship_types">subject</setting>
                 <setting name="restrict_to_types">Subject</setting>
                 <setting name="dont_include_subtypes_in_type_restriction">0</setting>
                 <setting name="list_format">list</setting>
@@ -5852,8 +5860,6 @@
                       <dt>Subject Dates:</dt>
                       <dd>^ca_occurrences.SubjectDates</dd>
                     </ifdef>
-                    <dt>Type:</dt>
-                    <dd>^ca_occurrences.type_id</dd>
                     <ifdef code="ca_occurrences.Description">
                       <dt>Description:</dt>
                       <dd>^ca_occurrences.Description</dd>
@@ -5863,7 +5869,7 @@
                       <dd>^ca_objects_x_occurrences.Association</dd>
                     </ifdef>
                     <ifdef code="ca_objects_x_occurrences.SubjectDates">
-                      <dt>Dates:</dt>
+                      <dt>Relationship Dates:</dt>
                       <dd>^ca_objects_x_occurrences.SubjectDates</dd>
                     </ifdef>
                   </dl>
@@ -7776,6 +7782,7 @@
             <setting name="restrict_to_relationship_types">depicts</setting>
             <setting name="restrict_to_relationship_types">used</setting>
             <setting name="restrict_to_relationship_types">describes</setting>
+            <setting name="restrict_to_relationship_types">subject</setting>
             <setting name="restrict_to_types">Subject</setting>
             <setting name="dont_include_subtypes_in_type_restriction">0</setting>
             <setting name="list_format">list</setting>
@@ -7794,8 +7801,6 @@
                       <dt>Subject Dates:</dt>
                       <dd>^ca_occurrences.SubjectDates</dd>
                     </ifdef>
-                    <dt>Type:</dt>
-                    <dd>^ca_occurrences.type_id</dd>
                     <ifdef code="ca_occurrences.Description">
                       <dt>Description:</dt>
                       <dd>^ca_occurrences.Description</dd>
@@ -7805,7 +7810,7 @@
                       <dd>^ca_objects_x_occurrences.Association</dd>
                     </ifdef>
                     <ifdef code="ca_objects_x_occurrences.SubjectDates">
-                      <dt>Dates:</dt>
+                      <dt>Relationship Dates:</dt>
                       <dd>^ca_objects_x_occurrences.SubjectDates</dd>
                     </ifdef>
                   </dl>
@@ -8079,6 +8084,7 @@
             <setting name="restrict_to_relationship_types">depicts</setting>
             <setting name="restrict_to_relationship_types">used</setting>
             <setting name="restrict_to_relationship_types">describes</setting>
+            <setting name="restrict_to_relationship_types">subject</setting>
             <setting name="restrict_to_types">Subject</setting>
             <setting name="dont_include_subtypes_in_type_restriction">0</setting>
             <setting name="list_format">list</setting>
@@ -8097,8 +8103,6 @@
                       <dt>Subject Dates:</dt>
                       <dd>^ca_occurrences.SubjectDates</dd>
                     </ifdef>
-                    <dt>Type:</dt>
-                    <dd>^ca_occurrences.type_id</dd>
                     <ifdef code="ca_occurrences.Description">
                       <dt>Description:</dt>
                       <dd>^ca_occurrences.Description</dd>
@@ -8108,7 +8112,7 @@
                       <dd>^ca_objects_x_occurrences.Association</dd>
                     </ifdef>
                     <ifdef code="ca_objects_x_occurrences.SubjectDates">
-                      <dt>Dates:</dt>
+                      <dt>Relationship Dates:</dt>
                       <dd>^ca_objects_x_occurrences.SubjectDates</dd>
                     </ifdef>
                   </dl>
@@ -8423,6 +8427,7 @@
             <setting name="restrict_to_relationship_types">depicts</setting>
             <setting name="restrict_to_relationship_types">used</setting>
             <setting name="restrict_to_relationship_types">describes</setting>
+            <setting name="restrict_to_relationship_types">subject</setting>
             <setting name="restrict_to_types">Subject</setting>
             <setting name="dont_include_subtypes_in_type_restriction">0</setting>
             <setting name="list_format">list</setting>
@@ -8441,8 +8446,6 @@
                       <dt>Subject Dates:</dt>
                       <dd>^ca_occurrences.SubjectDates</dd>
                     </ifdef>
-                    <dt>Type:</dt>
-                    <dd>^ca_occurrences.type_id</dd>
                     <ifdef code="ca_occurrences.Description">
                       <dt>Description:</dt>
                       <dd>^ca_occurrences.Description</dd>
@@ -8452,7 +8455,7 @@
                       <dd>^ca_objects_x_occurrences.Association</dd>
                     </ifdef>
                     <ifdef code="ca_objects_x_occurrences.SubjectDates">
-                      <dt>Dates:</dt>
+                      <dt>Relationship Dates:</dt>
                       <dd>^ca_objects_x_occurrences.SubjectDates</dd>
                     </ifdef>
                   </dl>
@@ -8702,6 +8705,7 @@
             <setting name="restrict_to_relationship_types">depicts</setting>
             <setting name="restrict_to_relationship_types">used</setting>
             <setting name="restrict_to_relationship_types">describes</setting>
+            <setting name="restrict_to_relationship_types">subject</setting>
             <setting name="restrict_to_types">Subject</setting>
             <setting name="dont_include_subtypes_in_type_restriction">0</setting>
             <setting name="list_format">list</setting>
@@ -8720,8 +8724,6 @@
                       <dt>Subject Dates:</dt>
                       <dd>^ca_occurrences.SubjectDates</dd>
                     </ifdef>
-                    <dt>Type:</dt>
-                    <dd>^ca_occurrences.type_id</dd>
                     <ifdef code="ca_occurrences.Description">
                       <dt>Description:</dt>
                       <dd>^ca_occurrences.Description</dd>
@@ -8731,7 +8733,7 @@
                       <dd>^ca_objects_x_occurrences.Association</dd>
                     </ifdef>
                     <ifdef code="ca_objects_x_occurrences.SubjectDates">
-                      <dt>Dates:</dt>
+                      <dt>Relationship Dates:</dt>
                       <dd>^ca_objects_x_occurrences.SubjectDates</dd>
                     </ifdef>
                   </dl>


### PR DESCRIPTION
* Remove extra subject types from the installation profile
* Make `Association` field wider and taller
* Remove `Type` from related subjects as all subjects have type of `Subject`
* Rename `Dates` on subject joins to `Relationship Dates`
* Make `subject` relationship type visible in related subject displays
* This relates to RWAHS-262 and RWAHS-147