### PR TITLE
RWAHS-255 Use markup to prevent title wrapping.

### DIFF
--- a/profile/rwahs.xml
+++ b/profile/rwahs.xml
@@ -7779,10 +7779,13 @@
         <permission group="memorial" access="read"/>
       </groupAccess>
       <bundlePlacements>
-        <placement code="preferred_labels">
-          <bundle>ca_object_labels.name</bundle>
+        <placement code="ca_objects_preferred_labels">
+          <bundle>ca_objects.preferred_labels</bundle>
           <settings>
             <setting name="label" locale="en_AU">Title</setting>
+            <setting name="format"><![CDATA[<nobr>^ca_objects.preferred_labels.name</nobr>]]></setting>
+            <setting name="delimiter"><![CDATA[]]></setting>
+            <setting name="maximum_length"><![CDATA[100]]></setting>
           </settings>
         </placement>
         <placement code="Author">
@@ -7830,10 +7833,13 @@
         </label>
       </labels>
       <bundlePlacements>
-        <placement code="preferred_labels">
-          <bundle>ca_object_labels.name</bundle>
+        <placement code="ca_objects_preferred_labels">
+          <bundle>ca_objects.preferred_labels</bundle>
           <settings>
-            <setting name="label" locale="en_AU">Item Name</setting>
+            <setting name="label" locale="en_AU">Title</setting>
+            <setting name="format"><![CDATA[<nobr>^ca_objects.preferred_labels.name</nobr>]]></setting>
+            <setting name="delimiter"><![CDATA[]]></setting>
+            <setting name="maximum_length"><![CDATA[100]]></setting>
           </settings>
         </placement>
         <placement code="ItemDates">

--- a/profile/rwahs.xml
+++ b/profile/rwahs.xml
@@ -7783,7 +7783,7 @@
           <bundle>ca_objects.preferred_labels</bundle>
           <settings>
             <setting name="label" locale="en_AU">Title</setting>
-            <setting name="format"><![CDATA[<nobr>^ca_objects.preferred_labels.name</nobr>]]></setting>
+            <setting name="format"><![CDATA[<div style="min-width:30em;">^preferred_labels</div>]]></setting>
             <setting name="delimiter"><![CDATA[]]></setting>
             <setting name="maximum_length"><![CDATA[100]]></setting>
           </settings>
@@ -7837,7 +7837,7 @@
           <bundle>ca_objects.preferred_labels</bundle>
           <settings>
             <setting name="label" locale="en_AU">Title</setting>
-            <setting name="format"><![CDATA[<nobr>^ca_objects.preferred_labels.name</nobr>]]></setting>
+            <setting name="format"><![CDATA[<div style="min-width:30em;">^preferred_labels</div>]]></setting>
             <setting name="delimiter"><![CDATA[]]></setting>
             <setting name="maximum_length"><![CDATA[100]]></setting>
           </settings>


### PR DESCRIPTION
+ Change `bundle` from `ca_object_labels.name` to `ca_objects.preferred_labels`.
+ Set the `format` setting to a `<nobr>` wrapped value.
+ This was done via the UI so there are some other settings that have default values.
+ Applied to the two existing search displays.