### PR TITLE
Make generated displays use a `format` setting

### DIFF
--- a/profile/rwahs.xml
+++ b/profile/rwahs.xml
@@ -8371,7 +8371,7 @@
             <setting name="list_format">list</setting>
             <setting name="sortDirection">ASC</setting>
             <setting name="dontShowDeleteButton">0</setting>
-            <setting name="display_template"><![CDATA[
+            <setting name="format"><![CDATA[
 
                   <dl>
                     <dt>Subject:</dt>
@@ -8469,7 +8469,7 @@
             <setting name="minRelationshipsPerRow">0</setting>
             <setting name="maxRelationshipsPerRow">255</setting>
             <setting name="showCurrentOnly">0</setting>
-            <setting name="display_template"><![CDATA[
+            <setting name="format"><![CDATA[
                   <dl>
                     <dt>Donor Name:
                     </dt>
@@ -8628,7 +8628,7 @@
             <setting name="list_format">list</setting>
             <setting name="sortDirection">ASC</setting>
             <setting name="dontShowDeleteButton">0</setting>
-            <setting name="display_template"><![CDATA[
+            <setting name="format"><![CDATA[
 
                   <dl>
                     <dt>Subject:</dt>
@@ -8743,7 +8743,7 @@
             <setting name="minRelationshipsPerRow">0</setting>
             <setting name="maxRelationshipsPerRow">255</setting>
             <setting name="showCurrentOnly">0</setting>
-            <setting name="display_template"><![CDATA[
+            <setting name="format"><![CDATA[
                   <dl>
                     <dt>Donor Name:
                     </dt>
@@ -8857,7 +8857,7 @@
             <setting name="maxRelationshipsPerRow">1</setting>
             <setting name="showCurrentOnly">1</setting>
             <setting name="useHierarchicalBrowser">1</setting>
-            <setting name="display_template"><![CDATA[
+            <setting name="format"><![CDATA[
 
                   <unit relativeTo="ca_storage_locations">
                     <unit relativeTo="ca_storage_locations.hierarchy">
@@ -8873,19 +8873,7 @@
           <settings>
             <setting name="label" locale="en_AU">Stored Location</setting>
             <setting name="locationTrackingMode">ca_movements</setting>
-            <setting name="displayTemplate"><![CDATA[
-
-                  <unit relativeTo="ca_movements">
-                    <unit relativeTo="ca_storage_locations">
-                      <unit relativeTo="ca_storage_locations.hierarchy">
-                        <l>^preferred_labels</l>
-                      </unit>
-                    </unit>
-                    (Status: ^LocationStatus, Authorised by: ^AuthorizedBy on ^MovementDate)
-                  </unit>
-
-                  ]]></setting>
-            <setting name="historyTemplate"><![CDATA[
+            <setting name="format"><![CDATA[
 
                   <unit relativeTo="ca_movements">
                     <unit relativeTo="ca_storage_locations">
@@ -8993,7 +8981,7 @@
             <setting name="list_format">list</setting>
             <setting name="sortDirection">ASC</setting>
             <setting name="dontShowDeleteButton">0</setting>
-            <setting name="display_template"><![CDATA[
+            <setting name="format"><![CDATA[
 
                   <dl>
                     <dt>Subject:</dt>
@@ -9064,7 +9052,7 @@
             <setting name="showCurrentOnly">0</setting>
             <setting name="useHierarchicalBrowser">1</setting>
             <setting name="restrict_to_lists">Classification</setting>
-            <setting name="display_template"><![CDATA[
+            <setting name="format"><![CDATA[
                   <unit relativeTo="ca_list_items">
                     <unit relativeTo="ca_list_items.hierarchy">
                       <l>^ca_list_items.preferred_labels.name_singular</l>
@@ -9110,7 +9098,7 @@
             <setting name="minRelationshipsPerRow">0</setting>
             <setting name="maxRelationshipsPerRow">255</setting>
             <setting name="showCurrentOnly">0</setting>
-            <setting name="display_template"><![CDATA[
+            <setting name="format"><![CDATA[
 
                   <unit relativeTo="ca_occurrences">
                     <l>^preferred_labels (^idno)</l>
@@ -9235,7 +9223,7 @@
             <setting name="list_format">list</setting>
             <setting name="sortDirection">ASC</setting>
             <setting name="dontShowDeleteButton">0</setting>
-            <setting name="display_template"><![CDATA[
+            <setting name="format"><![CDATA[
 
                   <dl>
                     <dt>Subject:</dt>
@@ -9312,7 +9300,7 @@
             <setting name="minRelationshipsPerRow">0</setting>
             <setting name="maxRelationshipsPerRow">255</setting>
             <setting name="showCurrentOnly">0</setting>
-            <setting name="display_template"><![CDATA[
+            <setting name="format"><![CDATA[
                   <dl>
                     <dt>Donor Name:
                     </dt>
@@ -9717,7 +9705,7 @@
             <setting name="list_format">bubbles</setting>
             <setting name="locationTrackingMode">ca_movements</setting>
             <setting name="colorItem">#ffffff</setting>
-            <setting name="displayTemplate"><![CDATA[
+            <setting name="format"><![CDATA[
                   <unit relativeTo="ca_objects">
                     <l>^ca_objects.preferred_labels (^ca_objects.idno)</l>
                   </unit>
@@ -9756,7 +9744,7 @@
             <setting name="list_format">bubbles</setting>
             <setting name="sortDirection">ASC</setting>
             <setting name="dontShowDeleteButton">0</setting>
-            <setting name="display_template"><![CDATA[
+            <setting name="format"><![CDATA[
                   <unit relativeTo="ca_storage_locations">
                     <unit relativeTo="ca_storage_locations.hierarchy">
                       <l>^preferred_labels</l>

--- a/transforms/derive-displays.xslt
+++ b/transforms/derive-displays.xslt
@@ -11,7 +11,7 @@
   </xsl:template>
 
   <!-- Don't munge the CDATA sections in UI placement template settings. -->
-  <xsl:template match="/profile/userInterfaces/userInterface/screens/screen/bundlePlacements/placement/settings/setting[substring(@name, string-length(@name) - 6) = 'emplate']">
+  <xsl:template match="/profile/userInterfaces/userInterface/screens/screen/bundlePlacements/placement/settings/setting[@name = 'displayTemplate' or @name = 'display_template' or @name = 'format' or @name = 'historyTemplate']">
     <xsl:element name="setting">
       <xsl:copy-of select="@name" />
       <xsl:text disable-output-escaping="yes">&lt;![CDATA[</xsl:text>
@@ -145,15 +145,16 @@
             </xsl:element>
             <xsl:element name="settings">
               <xsl:for-each select="settings/setting">
-                <xsl:if test="substring(@name, string-length(@name) - 6) = 'emplate'">
+                <xsl:if test="@name = 'displayTemplate' or @name = 'display_template' or @name = 'format'">
                   <xsl:element name="setting">
                     <xsl:copy-of select="@name" />
+                    <xsl:attribute name="name"><xsl:text>format</xsl:text></xsl:attribute>
                     <xsl:text disable-output-escaping="yes">&lt;![CDATA[</xsl:text>
                     <xsl:value-of select="text()" disable-output-escaping="yes"/>
                     <xsl:text disable-output-escaping="yes">]]&gt;</xsl:text>
                   </xsl:element>
                 </xsl:if>
-                <xsl:if test="substring(@name, string-length(@name) - 6) != 'emplate'">
+                <xsl:if test="@name != 'displayTemplate' and @name != 'display_template' and @name != 'format'  and @name != 'historyTemplate'">
                   <xsl:copy-of select="."/>
                 </xsl:if>
               </xsl:for-each>


### PR DESCRIPTION
* Be explicit about the template fields that we are not munging
 - display_template, displayTemplate become `format`
 - discard `historyTemplate` in derived displays